### PR TITLE
Release 200.0.0 beta 1

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -11,7 +11,6 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         maven { url 'https://esri.jfrog.io/artifactory/arcgis' }
-        maven { url 'https://olympus.esri.com/artifactory/arcgisruntime-repo/' }
     }
 }
 

--- a/version.gradle
+++ b/version.gradle
@@ -12,7 +12,7 @@ ext {
     appcompatVersion = '1.3.0'
     constraintLayoutVersion = '2.1.4'
     multidexVersion = '2.0.1'
-    arcgisVersion = '200.0.0-3709'
+    arcgisVersion = '200.0.0-beta01'
     materialVersion = '1.6.1'
     recyclerViewVersion = '1.1.0'
     // plugin versions


### PR DESCRIPTION
## Description
Updated `arcgisVersion` -> `200.0.0-beta01` beta release version and removed `olympus` atrifactory. The next release will be developed on the `v.next` branch. 

## Links and Data
Sample Epic: `runtime/kotlin/issues/1617`
