### PR TITLE
Website snippets

### DIFF
--- a/add-feature-layers/README.metadata.json
+++ b/add-feature-layers/README.metadata.json
@@ -37,8 +37,8 @@
         "ShapefileFeatureTable"
     ],
     "snippets": [
-        "src/main/java/com/esri/arcgismaps/sample/addfeaturelayers/DownloadActivity.kt",
-        "src/main/java/com/esri/arcgismaps/sample/addfeaturelayers/MainActivity.kt"
+        "src/main/java/com/esri/arcgismaps/sample/addfeaturelayers/MainActivity.kt",
+        "src/main/java/com/esri/arcgismaps/sample/addfeaturelayers/DownloadActivity.kt"
     ],
     "title": "Add feature layers"
 }

--- a/display-map-from-mobile-map-package/README.metadata.json
+++ b/display-map-from-mobile-map-package/README.metadata.json
@@ -22,8 +22,8 @@
     "MobileMapPackage"
   ],
   "snippets": [
-    "src/main/java/com/esri/arcgismaps/sample/displaymapfrommobilemappackage/DownloadActivity.kt",
-    "src/main/java/com/esri/arcgismaps/sample/displaymapfrommobilemappackage/MainActivity.kt"
+    "src/main/java/com/esri/arcgismaps/sample/displaymapfrommobilemappackage/MainActivity.kt",
+    "src/main/java/com/esri/arcgismaps/sample/displaymapfrommobilemappackage/DownloadActivity.kt"
   ],
   "title": "Display map from mobile map package"
 }


### PR DESCRIPTION
## Description
This PR is to change the order of the snippet first in the “[Sample Code](https://developers.arcgis.com/android/java/sample-code/group-layers/#sample-code)” section. Right now the website displays the code snippet in order of the `snippets` tag the metadata JSON file [here](https://github.com/Esri/arcgis-maps-sdk-kotlin-samples/blob/main/display-map-from-mobile-map-package/README.metadata.json#L25). 

As you can see, `MainActivity.kt` is not shown first by default, and this PR re-orders the snippets to display the snippet first! 

## Links and Data
Sample Epic: `runtime/kotlin/issues/1632`
