### PR TITLE
Change API Key to match Java

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Once the project is cloned to disk you can import into Android Studio:
 Accessing Esri location services, including basemaps, routing, and geocoding, requires authentication using either an API Key or an ArcGIS identity:
  1. API key: A permanent key that gives your application access to Esri location services. Visit your [ArcGIS Developers Dashboard](https://developers.arcgis.com/dashboard) to create a new API key or access an existing API key.
  
-The Android samples in this repository have been structured to use an API key, set once, which will run in all samples. Set your API key in the `gradle.properties` file located in the `/.gradle` folder within your home directory (`/Users/<user_name>/.gradle/gradle.properties`). The API_KEY property should contain quotes around the key itself: `API_KEY = "YOUR_API_KEY"`
+The Android samples in this repository have been structured to use an API key, set once, which will run in all samples. Set your API key in the `gradle.properties` file located in the `/.gradle` folder within your home directory (`/Users/<user_name>/.gradle/gradle.properties`). The value of the apiKey property should not be quoted: `apiKey = <copy your actual 100-character API Key here>`.
 
 2. ArcGIS identity: An ArcGIS named user account that is a member of an organization in ArcGIS Online or ArcGIS Enterprise.
 

--- a/add-feature-layers/build.gradle
+++ b/add-feature-layers/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField("String", "API_KEY", "\"$apiKey\"")
     }
 
     buildTypes {

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ task apiKey {
     if (!apiKeyFile.exists()) {
         print("Go to " + new URL("https://developers.arcgis.com/dashboard/") + " to get an API key.")
         print("Add your API Key to ${System.properties.getProperty("user.home")}\\.gradle\\gradle.properties.")
-        String apiKeyFileContents = "API_KEY = "
+        String apiKeyFileContents = "apiKey = "
         apiKeyFile.write(apiKeyFileContents)
     }
 }

--- a/change-viewpoint/build.gradle
+++ b/change-viewpoint/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField("String", "API_KEY", "\"$apiKey\"")
     }
 
     buildTypes {

--- a/clip-geometry/build.gradle
+++ b/clip-geometry/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField("String", "API_KEY", "\"$apiKey\"")
     }
 
     buildTypes {

--- a/create-planar-and-geodetic-buffers/build.gradle
+++ b/create-planar-and-geodetic-buffers/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField("String", "API_KEY", "\"$apiKey\"")
     }
 
     buildTypes {

--- a/cut-geometry/build.gradle
+++ b/cut-geometry/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField("String", "API_KEY", "\"$apiKey\"")
     }
 
     buildTypes {

--- a/display-device-location-with-nmea-data-sources/build.gradle
+++ b/display-device-location-with-nmea-data-sources/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField("String", "API_KEY", "\"$apiKey\"")
     }
 
     buildTypes {

--- a/display-map-from-mobile-map-package/build.gradle
+++ b/display-map-from-mobile-map-package/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField("String", "API_KEY", "\"$apiKey\"")
     }
 
     buildTypes {

--- a/display-map/build.gradle
+++ b/display-map/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField("String", "API_KEY", "\"$apiKey\"")
     }
 
     buildTypes {

--- a/download-vector-tiles-to-local-cache/build.gradle
+++ b/download-vector-tiles-to-local-cache/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField("String", "API_KEY", "\"$apiKey\"")
     }
 
     buildTypes {

--- a/find-address-with-reverse-geocode/build.gradle
+++ b/find-address-with-reverse-geocode/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField("String", "API_KEY", "\"$apiKey\"")
     }
 
     buildTypes {

--- a/find-nearest-vertex/build.gradle
+++ b/find-nearest-vertex/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField("String", "API_KEY", "\"$apiKey\"")
     }
 
     buildTypes {

--- a/find-route/build.gradle
+++ b/find-route/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField("String", "API_KEY", "\"$apiKey\"")
     }
 
     buildTypes {

--- a/generate-offline-map/build.gradle
+++ b/generate-offline-map/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField("String", "API_KEY", "\"$apiKey\"")
     }
 
     buildTypes {

--- a/render-multilayer-symbols/build.gradle
+++ b/render-multilayer-symbols/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField("String", "API_KEY", "\"$apiKey\"")
     }
 
     buildTypes {

--- a/select-features-in-feature-layer/build.gradle
+++ b/select-features-in-feature-layer/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField("String", "API_KEY", "\"$apiKey\"")
     }
 
     buildTypes {

--- a/set-viewpoint-rotation/build.gradle
+++ b/set-viewpoint-rotation/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField("String", "API_KEY", "\"$apiKey\"")
     }
 
     buildTypes {

--- a/show-device-location/build.gradle
+++ b/show-device-location/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField("String", "API_KEY", "\"$apiKey\"")
     }
 
     buildTypes {

--- a/show-result-of-spatial-operations/build.gradle
+++ b/show-result-of-spatial-operations/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField("String", "API_KEY", "\"$apiKey\"")
     }
 
     buildTypes {

--- a/show-result-of-spatial-relationships/build.gradle
+++ b/show-result-of-spatial-relationships/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField("String", "API_KEY", "\"$apiKey\"")
     }
 
     buildTypes {

--- a/style-graphics-with-renderer/build.gradle
+++ b/style-graphics-with-renderer/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField("String", "API_KEY", "\"$apiKey\"")
     }
 
     buildTypes {

--- a/style-graphics-with-symbols/build.gradle
+++ b/style-graphics-with-symbols/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField("String", "API_KEY", "\"$apiKey\"")
     }
 
     buildTypes {


### PR DESCRIPTION
Change API_KEY in gradle.properties to apiKey to match Java tutorials

## Description
Java samples repo uses an API key in the `gradle.properties` in `<userhome>/.gradle`, just as Kotlin samples repo does. They do not, however, use the same property name or value. 
The Java samples' property looks like this:

```
apiKey = <actual 100-character API Key here>
```

whereas Kotlin looks  ike this:

```
API_KEY = "<actual 100-character API Key here>"
```
Our new hire on the SDK docs team, Steve Rozic, found it quite confusing to end up  with `gradle.properties` file like this:

```
apiKey = <actual 100-character API Key here>
API_KEY = "<actual 100-character API Key here>"
```
He though it was an error and that one should be deleted. Of course, that would break the samples repo (and tutorials verification project) for the API Key that one deleted. Since the doc team covers for each other's vacations and other absences, it's important that any colleague can fairly easily fill in during those times, even in they are not completely familiar with the specific SDK.

To achieve that goal, I created this PR. It contains small changes in the `build.gradle` file of each tutorial app.

## Links and Data
- Java samples repo: https://github.com/Esri/arcgis-maps-sdk-java-samples

## What To Review
This PR changes the following.
- Changes this code:
   ```
   buildConfigField("String", "API_KEY", API_KEY)
   ``` 
  to this:
  ```
  buildConfigField("String", "API_KEY", "\"$apiKey\"")
  ```
- Updates the README to refer to `apiKey` instead of `API_KEY`.

Please evaluate these proposed changes, verify that they do not break the samples, and let me know if this is something you would contemplate doing. The PR works fine for me.