### PR TITLE
Replace DateTime with Instant

### DIFF
--- a/create-mobile-geodatabase/build.gradle
+++ b/create-mobile-geodatabase/build.gradle
@@ -31,5 +31,4 @@ dependencies {
     // lib dependencies from rootProject build.gradle
     implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
     implementation "com.google.android.material:material:$materialVersion"
-    implementation("org.jetbrains.kotlinx:kotlinx-datetime:$datetimeVersion")
 }

--- a/create-mobile-geodatabase/src/main/java/com/esri/arcgismaps/sample/createmobilegeodatabase/MainActivity.kt
+++ b/create-mobile-geodatabase/src/main/java/com/esri/arcgismaps/sample/createmobilegeodatabase/MainActivity.kt
@@ -47,9 +47,8 @@ import com.esri.arcgismaps.sample.createmobilegeodatabase.databinding.TableLayou
 import com.esri.arcgismaps.sample.createmobilegeodatabase.databinding.TableRowBinding
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import java.io.File
+import java.time.Instant
 
 class MainActivity : AppCompatActivity() {
 
@@ -210,7 +209,7 @@ class MainActivity : AppCompatActivity() {
     private fun addFeature(mapPoint: Point) {
         // set up the feature attributes
         val featureAttributes = mutableMapOf<String, Any>()
-        featureAttributes["collection_timestamp"] = Clock.System.now()
+        featureAttributes["collection_timestamp"] = Instant.now()
 
         // create a new feature at the mapPoint
         val feature = featureTable?.createFeature(featureAttributes, mapPoint)

--- a/navigate-route/build.gradle
+++ b/navigate-route/build.gradle
@@ -31,5 +31,4 @@ dependencies {
     // lib dependencies from rootProject build.gradle
     implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
     implementation "com.google.android.material:material:$materialVersion"
-    implementation("org.jetbrains.kotlinx:kotlinx-datetime:$datetimeVersion")
 }

--- a/navigate-route/src/main/java/com/esri/arcgismaps/sample/navigateroute/MainActivity.kt
+++ b/navigate-route/src/main/java/com/esri/arcgismaps/sample/navigateroute/MainActivity.kt
@@ -53,7 +53,7 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
-import kotlinx.datetime.Clock
+import java.time.Instant
 import java.util.concurrent.atomic.AtomicBoolean
 
 class MainActivity : AppCompatActivity() {
@@ -205,7 +205,7 @@ class MainActivity : AppCompatActivity() {
 
         // set up a simulated location data source which simulates movement along the route
         val simulationParameters = SimulationParameters(
-            Clock.System.now(),
+            Instant.now(),
             velocity = 35.0,
             horizontalAccuracy = 5.0,
             verticalAccuracy = 5.0

--- a/set-up-location-driven-geotriggers/build.gradle
+++ b/set-up-location-driven-geotriggers/build.gradle
@@ -31,5 +31,4 @@ dependencies {
     // lib dependencies from rootProject build.gradle
     implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
     implementation "com.google.android.material:material:$materialVersion"
-    implementation "org.jetbrains.kotlinx:kotlinx-datetime:0.4.0"
 }

--- a/set-up-location-driven-geotriggers/src/main/java/com/esri/arcgismaps/sample/setuplocationdrivengeotriggers/MainActivity.kt
+++ b/set-up-location-driven-geotriggers/src/main/java/com/esri/arcgismaps/sample/setuplocationdrivengeotriggers/MainActivity.kt
@@ -44,7 +44,7 @@ import com.esri.arcgismaps.sample.setuplocationdrivengeotriggers.databinding.Act
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
-import kotlinx.datetime.Clock
+import java.time.Instant
 
 class MainActivity : AppCompatActivity() {
 
@@ -85,7 +85,7 @@ class MainActivity : AppCompatActivity() {
         // create SimulationParameters starting at the current time,
         // a velocity of 10 m/s, and a horizontal and vertical accuracy of 0.0
         val simulationParameters = SimulationParameters(
-            Clock.System.now(),
+            Instant.now(),
             velocity = 3.0,
             horizontalAccuracy = 0.0,
             verticalAccuracy = 0.0

--- a/show-location-history/build.gradle
+++ b/show-location-history/build.gradle
@@ -31,5 +31,4 @@ dependencies {
     // lib dependencies from rootProject build.gradle
     implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
     implementation "com.google.android.material:material:$materialVersion"
-    implementation("org.jetbrains.kotlinx:kotlinx-datetime:$datetimeVersion")
 }

--- a/show-location-history/src/main/java/com/esri/arcgismaps/sample/showlocationhistory/MainActivity.kt
+++ b/show-location-history/src/main/java/com/esri/arcgismaps/sample/showlocationhistory/MainActivity.kt
@@ -44,7 +44,7 @@ import com.arcgismaps.mapping.view.GraphicsOverlay
 import com.esri.arcgismaps.sample.showlocationhistory.databinding.ActivityMainBinding
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
-import kotlinx.datetime.Clock
+import java.time.Instant
 
 class MainActivity : AppCompatActivity() {
 
@@ -93,7 +93,7 @@ class MainActivity : AppCompatActivity() {
         // create a simulated location data source from json data with simulation parameters to set a consistent velocity
         val simulatedLocationDataSource = SimulatedLocationDataSource(
             Geometry.fromJson(getString(R.string.polyline_data)) as Polyline,
-            SimulationParameters(Clock.System.now(), 30.0, 0.0, 0.0)
+            SimulationParameters(Instant.now(), 30.0, 0.0, 0.0)
         )
 
         // coroutine scope to collect data source location changes

--- a/version.gradle
+++ b/version.gradle
@@ -12,10 +12,9 @@ ext {
     appcompatVersion = '1.5.1'
     constraintLayoutVersion = '2.1.4'
     multidexVersion = '2.0.1'
-    arcgisVersion = '200.1.0-3812'
+    arcgisVersion = '200.1.0-3813'
     materialVersion = '1.7.0'
     recyclerViewVersion = '1.1.0'
-    datetimeVersion = '0.4.0'
     // plugin versions
     gradleVersion = '7.3.1'
     // java version


### PR DESCRIPTION
## Description
PR to replace and remove all references of Kotlin DateTime and replace them with Java Instant. 

## Links and Data
Sample Epic: `runtime/kotlin/issues/2063`

## What To Review
- Check if the use of `Instant.now()` would be the right implementation. Or `Instant.EPOCH`
