### PR TITLE
initial commit on fix-para-numbers-authen-with-oauth

### DIFF
--- a/authenticate-with-oauth/README.md
+++ b/authenticate-with-oauth/README.md
@@ -34,25 +34,28 @@ This sample takes advantage of Android's `ViewModel` to encapsulate launching th
 #### Setting up the Manifest.xml:
 
 1. Set the launch mode for the `OAuthUserSignInActivity` to route it's intent instance through a call to its `onNewIntent()` method, rather than creating a new instance of the activity. To find out more on setting the launch configuration of an activity, visit the [Android docs](https://developer.android.com/guide/topics/manifest/activity-element)
-```xml
-<activity 
-          android:name=".OAuthUserSignInActivity"
-          android:launchMode="singleTop"
-          ...
-```
 
-2. Set the `<intent-filter>` categories tags to be able to launch a custom browser tab. 
-```xml
-<category android:name="android.intent.category.DEFAULT" />
-<category android:name="android.intent.category.BROWSABLE" />
-```
+   ```xml
+   <activity 
+             android:name=".OAuthUserSignInActivity"
+             android:launchMode="singleTop"
+             ...
+   ```
+
+2. Set the `<intent-filter>` categories tags to be able to launch a custom browser tab.
+
+   ```xml
+   <category android:name="android.intent.category.DEFAULT" />
+   <category android:name="android.intent.category.BROWSABLE" />
+   ```
 
 3. Set the `data` tag to be able to use the redirect URI to navigate back to the app after prompting for OAuth credentials. To learn more on setting up the data specification to an intent filter, visit the [Android docs](https://developer.android.com/guide/topics/manifest/data-element).
-```xml
-<data
-    android:host="auth"
-    android:scheme="my-ags-app" />
-```
+
+   ```xml
+   <data
+       android:host="auth"
+       android:scheme="my-ags-app" />
+   ```
 
 ## Relevant API
 


### PR DESCRIPTION
## Description
Fix vertical spacing in the README for the **Authenticate with Oauth** sample -- in the **Setting the Manifest.xml** section. While the README looks fine in the Github.com repo, it looks like this after Gatsby has converted the .md into a web page:




## Links and Data
<!--
Sample Epic: `runtime/kotlin/issues/ISSUE_NUMBER`
-->
## What To Review
<!--
-  Review the code to make sure it is easy to follow like other samples on Android
- `README.md` and `README.metadata.json` files
-->

## How to Test
<!--
Run the sample on the sample viewer or the repo.
-->

<!-- OPTIONAL
## To Discuss
-->

<!-- OPTIONAL
## Screenshots
-->
