### PR TITLE
Render multilayer symbols patch

### DIFF
--- a/render-multilayer-symbols/src/main/java/com/esri/arcgismaps/sample/rendermultilayersymbols/MainActivity.kt
+++ b/render-multilayer-symbols/src/main/java/com/esri/arcgismaps/sample/rendermultilayersymbols/MainActivity.kt
@@ -56,9 +56,7 @@ import com.arcgismaps.mapping.view.Graphic
 import com.arcgismaps.mapping.view.GraphicsOverlay
 import com.esri.arcgismaps.sample.rendermultilayersymbols.databinding.ActivityMainBinding
 import com.google.android.material.snackbar.Snackbar
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private val Color.Companion.blue: Color
     get() {

--- a/render-multilayer-symbols/src/main/java/com/esri/arcgismaps/sample/rendermultilayersymbols/MainActivity.kt
+++ b/render-multilayer-symbols/src/main/java/com/esri/arcgismaps/sample/rendermultilayersymbols/MainActivity.kt
@@ -239,11 +239,13 @@ class MainActivity : AppCompatActivity() {
             // add loaded layer to the map
             addGraphicFromPictureMarkerSymbolLayer(pictureMarkerFromUri, 0.0)
             // load blue pin from as a bitmap
-            val bitmap = withContext(Dispatchers.Default) {
+            val bitmap = withContext(Dispatchers.IO) {
                 BitmapFactory.decodeResource(resources, R.drawable.blue_pin)
             }
             // load the PictureMarkerSymbolLayer using the bitmap drawable
-            val pictureMarkerFromCache = PictureMarkerSymbolLayer.createWithImage(BitmapDrawable(resources, bitmap))
+            val pictureMarkerFromCache = withContext(Dispatchers.IO) {
+                PictureMarkerSymbolLayer.createWithImage(BitmapDrawable(resources, bitmap))
+            }
             pictureMarkerFromCache.load().getOrElse {
                 showError("Picture marker symbol layer failed to load from bitmap: ${it.message}")
             }
@@ -262,7 +264,7 @@ class MainActivity : AppCompatActivity() {
      */
     private suspend fun addGraphicFromPictureMarkerSymbolLayer(
         pictureMarkerSymbolLayer: PictureMarkerSymbolLayer, offset: Double
-    ) = withContext(Dispatchers.Default) {
+    ) = withContext(Dispatchers.IO) {
         // wait for the picture marker symbol layer to load and check it has loaded
         pictureMarkerSymbolLayer.load().getOrElse {
             showError("Picture marker symbol layer failed to load: ${it.message}")

--- a/render-multilayer-symbols/src/main/java/com/esri/arcgismaps/sample/rendermultilayersymbols/MainActivity.kt
+++ b/render-multilayer-symbols/src/main/java/com/esri/arcgismaps/sample/rendermultilayersymbols/MainActivity.kt
@@ -56,7 +56,9 @@ import com.arcgismaps.mapping.view.Graphic
 import com.arcgismaps.mapping.view.GraphicsOverlay
 import com.esri.arcgismaps.sample.rendermultilayersymbols.databinding.ActivityMainBinding
 import com.google.android.material.snackbar.Snackbar
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 private val Color.Companion.blue: Color
     get() {
@@ -237,7 +239,9 @@ class MainActivity : AppCompatActivity() {
             // add loaded layer to the map
             addGraphicFromPictureMarkerSymbolLayer(pictureMarkerFromUri, 0.0)
             // load blue pin from as a bitmap
-            val bitmap = BitmapFactory.decodeResource(resources, R.drawable.blue_pin)
+            val bitmap = withContext(Dispatchers.Default) {
+                BitmapFactory.decodeResource(resources, R.drawable.blue_pin)
+            }
             // load the PictureMarkerSymbolLayer using the bitmap drawable
             val pictureMarkerFromCache = PictureMarkerSymbolLayer.createWithImage(BitmapDrawable(resources, bitmap))
             pictureMarkerFromCache.load().getOrElse {
@@ -256,24 +260,22 @@ class MainActivity : AppCompatActivity() {
      * The [offset] value used to keep a consistent distance between symbols in the same column.
      *
      */
-    private fun addGraphicFromPictureMarkerSymbolLayer(
+    private suspend fun addGraphicFromPictureMarkerSymbolLayer(
         pictureMarkerSymbolLayer: PictureMarkerSymbolLayer, offset: Double
-    ) {
-        lifecycleScope.launch {
-            // wait for the picture marker symbol layer to load and check it has loaded
-            pictureMarkerSymbolLayer.load().getOrElse {
-                showError("Picture marker symbol layer failed to load: ${it.message}")
-            }
-            // set the size of the layer and create a new multilayer point symbol from it
-            pictureMarkerSymbolLayer.size = 40.0
-            val multilayerPointSymbol = MultilayerPointSymbol(listOf(pictureMarkerSymbolLayer))
-            // create location for the symbol
-            val point = Point(-80.0, 20.0 - offset, SpatialReference.wgs84())
-
-            // create graphic with the location and symbol and add it to the graphics overlay
-            val graphic = Graphic(point, multilayerPointSymbol)
-            graphicsOverlay.graphics.add(graphic)
+    ) = withContext(Dispatchers.Default) {
+        // wait for the picture marker symbol layer to load and check it has loaded
+        pictureMarkerSymbolLayer.load().getOrElse {
+            showError("Picture marker symbol layer failed to load: ${it.message}")
         }
+        // set the size of the layer and create a new multilayer point symbol from it
+        pictureMarkerSymbolLayer.size = 40.0
+        val multilayerPointSymbol = MultilayerPointSymbol(listOf(pictureMarkerSymbolLayer))
+        // create location for the symbol
+        val point = Point(-80.0, 20.0 - offset, SpatialReference.wgs84())
+
+        // create graphic with the location and symbol and add it to the graphics overlay
+        val graphic = Graphic(point, multilayerPointSymbol)
+        graphicsOverlay.graphics.add(graphic)
     }
 
     /**

--- a/render-multilayer-symbols/src/main/java/com/esri/arcgismaps/sample/rendermultilayersymbols/MainActivity.kt
+++ b/render-multilayer-symbols/src/main/java/com/esri/arcgismaps/sample/rendermultilayersymbols/MainActivity.kt
@@ -227,31 +227,17 @@ class MainActivity : AppCompatActivity() {
      */
     private fun addImageGraphics() {
         // URI of image to display
-        val blueTentImageURI =
-            "https://static.arcgis.com/images/Symbols/OutdoorRecreation/Camping.png"
+        val blueTentImageURI = "https://static.arcgis.com/images/Symbols/OutdoorRecreation/Camping.png"
         // load the PictureMarkerSymbolLayer using the image URI
         val pictureMarkerFromUri = PictureMarkerSymbolLayer(blueTentImageURI)
-
-        lifecycleScope.launch {
-            pictureMarkerFromUri.load().getOrElse {
-                showError("Picture marker symbol layer failed to load from URI: ${it.message}")
-            }
-            // add loaded layer to the map
-            addGraphicFromPictureMarkerSymbolLayer(pictureMarkerFromUri, 0.0)
-            // load blue pin from as a bitmap
-            val bitmap = withContext(Dispatchers.IO) {
-                BitmapFactory.decodeResource(resources, R.drawable.blue_pin)
-            }
-            // load the PictureMarkerSymbolLayer using the bitmap drawable
-            val pictureMarkerFromCache = withContext(Dispatchers.IO) {
-                PictureMarkerSymbolLayer.createWithImage(BitmapDrawable(resources, bitmap))
-            }
-            pictureMarkerFromCache.load().getOrElse {
-                showError("Picture marker symbol layer failed to load from bitmap: ${it.message}")
-            }
-            // add loaded layer to the map
-            addGraphicFromPictureMarkerSymbolLayer(pictureMarkerFromCache, 40.0)
-        }
+        // add loaded layer to the map
+        addGraphicFromPictureMarkerSymbolLayer(pictureMarkerFromUri, 0.0)
+        // load blue pin from as a bitmap
+        val bitmap = BitmapFactory.decodeResource(resources, R.drawable.blue_pin)
+        // load the PictureMarkerSymbolLayer using the bitmap drawable
+        val pictureMarkerFromCache = PictureMarkerSymbolLayer.createWithImage(BitmapDrawable(resources, bitmap))
+        // add loaded layer to the map
+        addGraphicFromPictureMarkerSymbolLayer(pictureMarkerFromCache, 40.0)
     }
 
     /**
@@ -260,11 +246,10 @@ class MainActivity : AppCompatActivity() {
      *
      * The [pictureMarkerSymbolLayer] to be loaded.
      * The [offset] value used to keep a consistent distance between symbols in the same column.
-     *
      */
-    private suspend fun addGraphicFromPictureMarkerSymbolLayer(
+    private fun addGraphicFromPictureMarkerSymbolLayer(
         pictureMarkerSymbolLayer: PictureMarkerSymbolLayer, offset: Double
-    ) = withContext(Dispatchers.IO) {
+    ) = lifecycleScope.launch {
         // wait for the picture marker symbol layer to load and check it has loaded
         pictureMarkerSymbolLayer.load().getOrElse {
             showError("Picture marker symbol layer failed to load: ${it.message}")

--- a/version.gradle
+++ b/version.gradle
@@ -1,6 +1,6 @@
 ext {
     // ArcGIS Maps SDK for Kotlin version
-    arcgisVersion = '200.1.0-3834'
+    arcgisVersion = '200.1.0-3835'
     // SDK versions
     compileSdkVersion = 33
     minSdkVersion = 26

--- a/version.gradle
+++ b/version.gradle
@@ -1,6 +1,6 @@
 ext {
     // ArcGIS Maps SDK for Kotlin version
-    arcgisVersion = '200.1.0-3835'
+    arcgisVersion = '200.1.0-3836'
     // SDK versions
     compileSdkVersion = 33
     minSdkVersion = 26


### PR DESCRIPTION
## Description
PR to fix the `PictureMarkerSymbolLayer` flaky loading behavior in the _Render multilayer symbols_ sample. 

## Links and Data
Sample Epic: `runtime/kotlin/issues/2226 `
