### PR TITLE
Sample patches

### DIFF
--- a/authenticate-with-oauth/src/main/java/com/esri/arcgismaps/sample/authenticatewithoauth/MainActivity.kt
+++ b/authenticate-with-oauth/src/main/java/com/esri/arcgismaps/sample/authenticatewithoauth/MainActivity.kt
@@ -47,7 +47,7 @@ class MainActivity : AppCompatActivity() {
 
     // to view the traffic layer in the portal, you must enter valid ArcGIS Online credentials.
     private val portal by lazy {
-        Portal(getString(R.string.portal_url), Portal.Connection.Authenticated)
+        Portal(getString(R.string.auth_portal_url), Portal.Connection.Authenticated)
     }
 
     private val oAuthConfiguration by lazy {

--- a/authenticate-with-oauth/src/main/res/values/strings.xml
+++ b/authenticate-with-oauth/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="app_name">Authenticate with OAuth</string>
-    <string name="portal_url">https://www.arcgis.com/home/item.html?id=e5039444ef3c48b8a8fdc9227f9be7c1</string>
+    <string name="auth_portal_url">https://www.arcgis.com/home/item.html?id=e5039444ef3c48b8a8fdc9227f9be7c1</string>
     <string name="oauth_client_id">lgAdHkYZYlwwfAhC</string>
     <string name="oauth_redirect_uri">my-ags-app://auth</string>
 </resources>

--- a/download-vector-tiles-to-local-cache/README.metadata.json
+++ b/download-vector-tiles-to-local-cache/README.metadata.json
@@ -31,7 +31,7 @@
         "VectorTileCache"
     ],
     "snippets": [
-        "src/main/java/com/esri/com/arcgismaps/sample/downloadvectortilestolocalcache/MainActivity.kt"
+        "src/main/java/com/esri/arcgismaps/sample/downloadvectortilestolocalcache/MainActivity.kt"
     ],
     "title": "Download vector tiles to local cache"
 }


### PR DESCRIPTION
## Description

- Updated the `downloadvectortilestolocalcache` snippet to the correct package name
- Renamed Oauth protal URL to avoid a conflict with Generate offline map using android jetpack workmanager sample. Both samples have the same string name `<string name="portal_url">`

## Links and Data
Sample issue: `runtime/kotlin/issues/2358`

