### PR TITLE
Patch for multiple file-providers

### DIFF
--- a/create-mobile-geodatabase/src/main/AndroidManifest.xml
+++ b/create-mobile-geodatabase/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
 
@@ -20,12 +21,14 @@
         </activity>
         <provider
             android:name="androidx.core.content.FileProvider"
-            android:authorities="com.esri.arcgismaps.fileprovider"
+            android:authorities="@string/provider_authority"
+            tools:replace="android:authorities"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/provider" />
+                android:resource="@xml/provider"
+                tools:replace="android:resource"/>
         </provider>
     </application>
 

--- a/create-mobile-geodatabase/src/main/java/com/esri/arcgismaps/sample/createmobilegeodatabase/MainActivity.kt
+++ b/create-mobile-geodatabase/src/main/java/com/esri/arcgismaps/sample/createmobilegeodatabase/MainActivity.kt
@@ -113,7 +113,7 @@ class MainActivity : AppCompatActivity() {
             // get the URI of the geodatabase file using FileProvider
             val geodatabaseURI = FileProvider.getUriForFile(
                 this,
-                getString(R.string.file_provider_package),
+                getString(R.string.provider_authority),
                 File(geodatabase?.path.toString())
             )
 

--- a/create-mobile-geodatabase/src/main/res/values/strings.xml
+++ b/create-mobile-geodatabase/src/main/res/values/strings.xml
@@ -4,7 +4,7 @@
     <string name="share_mobile_geodatabase">Create and share mobile geodatabase</string>
     <string name="view_table">View table</string>
     <string name="attribute_table_hint">Attribute table loaded from the mobile geodatabase file. File can be loaded on ArcGIS Pro or ArcGIS Runtime</string>
-    <string name="file_provider_package">com.esri.arcgismaps.fileprovider</string>
     <string name="oid">OID</string>
     <string name="collection_timestamp">Collection Timestamp</string>
+    <string name="provider_authority">com.esri.arcgismaps.sample.createmobilegeodatabase.provider</string>
 </resources>

--- a/edit-feature-attachments/src/main/AndroidManifest.xml
+++ b/edit-feature-attachments/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
 
@@ -10,15 +11,6 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <provider
-            android:name="androidx.core.content.FileProvider"
-            android:authorities="${applicationId}.provider"
-            android:exported="false"
-            android:grantUriPermissions="true">
-            <meta-data
-                android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/provider_paths" />
-        </provider>
         <activity
             android:name=".MainActivity"
             android:exported="true">
@@ -28,6 +20,17 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="@string/provider_authority"
+            tools:replace="android:authorities"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths"
+                tools:replace="android:resource"/>
+        </provider>
     </application>
 
 </manifest>

--- a/edit-feature-attachments/src/main/java/com/esri/arcgismaps/sample/editfeatureattachments/MainActivity.kt
+++ b/edit-feature-attachments/src/main/java/com/esri/arcgismaps/sample/editfeatureattachments/MainActivity.kt
@@ -194,7 +194,7 @@ class MainActivity : AppCompatActivity() {
 
         // file provider URI
         val contentUri = FileProvider.getUriForFile(
-            applicationContext, applicationContext.packageName + ".provider", file
+            applicationContext, getString(R.string.provider_authority), file
         )
         // open the file in gallery
         val imageIntent = Intent().apply {

--- a/edit-feature-attachments/src/main/res/values/strings.xml
+++ b/edit-feature-attachments/src/main/res/values/strings.xml
@@ -13,4 +13,5 @@
     <string name="edit_attachments">Edit attachments</string>
     <string name="done">Done</string>
     <string name="add_attachment">Add attachment</string>
+    <string name="provider_authority">com.esri.arcgismaps.sample.editfeatureattachments.provider</string>
 </resources>


### PR DESCRIPTION
## Description
The sample viewer seems to conflict with two samples that use `<provider>`.  Updated the provider authority and added replace overrides to avoid conflict. 


## Links and Data
Sample Epic: `runtime/kotlin/issues/2357 `

## What To Review
- Build the sample viewer using this branch to confirm if the samples run without errors. 
    - Edit feature attachments
    - Create mobile geodatabase
