### PR TITLE
Generate geodatabase border

### DIFF
--- a/generate-geodatabase-replica-from-feature-service/src/main/java/com/esri/arcgismaps/sample/generategeodatabasereplicafromfeatureservice/MainActivity.kt
+++ b/generate-geodatabase-replica-from-feature-service/src/main/java/com/esri/arcgismaps/sample/generategeodatabasereplicafromfeatureservice/MainActivity.kt
@@ -202,6 +202,7 @@ class MainActivity : AppCompatActivity() {
                     showError("Error creating geodatabase parameters")
                     return@launch
                 }.apply {
+                    // set the parameters to only create a replica of the Trees (0) layer
                     layerOptions.removeIf { layerOptions ->
                         layerOptions.layerId != 0L
                     }

--- a/generate-geodatabase-replica-from-feature-service/src/main/java/com/esri/arcgismaps/sample/generategeodatabasereplicafromfeatureservice/MainActivity.kt
+++ b/generate-geodatabase-replica-from-feature-service/src/main/java/com/esri/arcgismaps/sample/generategeodatabasereplicafromfeatureservice/MainActivity.kt
@@ -38,6 +38,7 @@ import com.arcgismaps.mapping.symbology.SimpleLineSymbol
 import com.arcgismaps.mapping.symbology.SimpleLineSymbolStyle
 import com.arcgismaps.mapping.view.Graphic
 import com.arcgismaps.mapping.view.GraphicsOverlay
+import com.arcgismaps.mapping.view.ScreenCoordinate
 import com.arcgismaps.tasks.geodatabase.GenerateGeodatabaseJob
 import com.arcgismaps.tasks.geodatabase.GeodatabaseSyncTask
 import com.esri.arcgismaps.sample.generategeodatabasereplicafromfeatureservice.databinding.ActivityMainBinding
@@ -62,6 +63,10 @@ class MainActivity : AppCompatActivity() {
         activityMainBinding.generateButton
     }
 
+    private val resetButton by lazy {
+        activityMainBinding.resetButton
+    }
+
     // shows the geodatabase loading progress
     private val progressDialog by lazy {
         GenerateGeodatabaseDialogLayoutBinding.inflate(layoutInflater)
@@ -72,8 +77,7 @@ class MainActivity : AppCompatActivity() {
         getExternalFilesDir(null)?.path + getString(R.string.portland_trees_geodatabase_file)
     }
 
-    // a red boundary line showing the filtered map extents for the features
-    private val boundarySymbol = SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Color.red, 5f)
+    private val downloadArea: Graphic = Graphic()
 
     // creates a graphic overlay
     private val graphicsOverlay: GraphicsOverlay = GraphicsOverlay()
@@ -111,10 +115,20 @@ class MainActivity : AppCompatActivity() {
 
         // set the button's onClickListener
         generateButton.setOnClickListener {
-            mapView.visibleArea?.let { polygon ->
-                // start the geodatabase generation process
-                generateGeodatabase(geodatabaseSyncTask, map, polygon.extent)
-            }
+            // start the geodatabase generation process
+            generateGeodatabase(geodatabaseSyncTask, map, downloadArea.geometry?.extent)
+        }
+
+        resetButton.setOnClickListener {
+            // clear any layers already on the map
+            map.operationalLayers.clear()
+            // clear all symbols drawn
+            graphicsOverlay.graphics.clear()
+            // add the download boundary
+            graphicsOverlay.graphics.add(downloadArea)
+            // show generate button
+            generateButton.visibility = View.VISIBLE
+            resetButton.visibility = View.GONE
         }
 
         lifecycleScope.launch {
@@ -132,6 +146,29 @@ class MainActivity : AppCompatActivity() {
 
             // enable the generate button since the task is now loaded
             generateButton.isEnabled = true
+
+
+            // create a symbol to show a box around the extent we want to download
+            downloadArea.symbol = SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Color.red, 2F)
+            // add the graphic to the graphics overlay when it is created
+            graphicsOverlay.graphics.add(downloadArea)
+
+            mapView.viewpointChanged.collect {
+                // define screen area to create replica
+                val minScreenPoint = ScreenCoordinate(200.0, 200.0)
+                val maxScreenPoint = ScreenCoordinate(
+                    mapView.measuredWidth - 200.0,
+                    mapView.measuredHeight - 200.0
+                )
+                // convert screen points to map points
+                val minPoint = mapView.screenToLocation(minScreenPoint)
+                val maxPoint = mapView.screenToLocation(maxScreenPoint)
+                // use the points to define and return an envelope
+                if (minPoint != null && maxPoint != null) {
+                    val envelope = Envelope(minPoint, maxPoint)
+                    downloadArea.geometry = envelope
+                }
+            }
         }
     }
 
@@ -142,17 +179,11 @@ class MainActivity : AppCompatActivity() {
     private fun generateGeodatabase(
         geodatabaseSyncTask: GeodatabaseSyncTask,
         map: ArcGISMap,
-        extents: Envelope
+        extents: Envelope?
     ) {
-        // clear any layers already on the map
-        map.operationalLayers.clear()
-        // clear all symbols drawn
-        graphicsOverlay.graphics.clear()
-
-        // create a boundary representing the extents selected
-        val boundary = Graphic(extents, boundarySymbol)
-        // add this boundary to the graphics overlay
-        graphicsOverlay.graphics.add(boundary)
+        if(extents == null){
+            return showError("Download area extent is null")
+        }
 
         lifecycleScope.launch {
             // create generate geodatabase parameters for the selected extents
@@ -198,6 +229,9 @@ class MainActivity : AppCompatActivity() {
                     dialog.dismiss()
                     // unregister since we are not syncing
                     geodatabaseSyncTask.unregisterGeodatabase(geodatabase)
+                    // show reset button as the task is now complete
+                    generateButton.visibility = View.GONE
+                    resetButton.visibility = View.VISIBLE
                 }
         }
     }
@@ -206,6 +240,11 @@ class MainActivity : AppCompatActivity() {
      * Loads the [geodatabase] and renders the feature layers on to the [map]
      */
     private suspend fun loadGeodatabase(geodatabase: Geodatabase, map: ArcGISMap) {
+        // clear any layers already on the map
+        map.operationalLayers.clear()
+        // clear all symbols drawn
+        graphicsOverlay.graphics.clear()
+
         // load the geodatabase
         geodatabase.load().onFailure {
             // if the load failed, show the error and return
@@ -216,8 +255,6 @@ class MainActivity : AppCompatActivity() {
         map.operationalLayers += geodatabase.featureTables.map { featureTable ->
             FeatureLayer.createWithFeatureTable(featureTable)
         }
-        // hide the generate button as the task is now complete
-        generateButton.visibility = View.GONE
     }
 
     /**

--- a/generate-geodatabase-replica-from-feature-service/src/main/res/layout/activity_main.xml
+++ b/generate-geodatabase-replica-from-feature-service/src/main/res/layout/activity_main.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
@@ -12,39 +12,47 @@
             android:id="@+id/mapView"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            app:layout_constraintBottom_toTopOf="@+id/generateButton"
+            app:layout_constraintBottom_toTopOf="@+id/constraintLayout"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 
         </com.arcgismaps.mapping.view.MapView>
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/generateButton"
-            style="?attr/materialButtonOutlinedStyle"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/constraintLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:padding="16dp"
-            android:text="@string/generate_button_text"
-            android:enabled="false"
-            android:textAllCaps="false"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
+            app:layout_constraintStart_toStartOf="parent">
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/resetButton"
-            style="?attr/materialButtonOutlinedStyle"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:padding="16dp"
-            android:visibility="gone"
-            android:text="@string/reset_map"
-            android:enabled="false"
-            android:textAllCaps="false"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/generateButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:enabled="false"
+                android:text="@string/generate_button_text"
+                android:textAllCaps="false"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.5"
+                app:layout_constraintStart_toEndOf="@+id/resetButton" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/resetButton"
+                style="@style/OutlineButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:enabled="false"
+                android:text="@string/reset_map"
+                android:textAllCaps="false"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@+id/generateButton"
+                app:layout_constraintHorizontal_bias="0.5"
+                app:layout_constraintStart_toStartOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/generate-geodatabase-replica-from-feature-service/src/main/res/layout/activity_main.xml
+++ b/generate-geodatabase-replica-from-feature-service/src/main/res/layout/activity_main.xml
@@ -32,5 +32,19 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent" />
 
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/resetButton"
+            style="?attr/materialButtonOutlinedStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="16dp"
+            android:visibility="gone"
+            android:text="@string/reset_map"
+            android:enabled="false"
+            android:textAllCaps="false"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/generate-geodatabase-replica-from-feature-service/src/main/res/values/strings.xml
+++ b/generate-geodatabase-replica-from-feature-service/src/main/res/values/strings.xml
@@ -4,4 +4,5 @@
     <string name="generate_button_text">Generate</string>
     <string name="dialog_title">Fetching result</string>
     <string name="portland_trees_geodatabase_file">/portland_trees_gdb.geodatabase</string>
+    <string name="reset_map">Reset map</string>
 </resources>


### PR DESCRIPTION
## Description
This PR adds a red border similar to `Generate offline map` sample and implemented a reset button to clear map.

## Links and Data
Sample Epic: `runtime/kotlin/issues/2373` 

## To Discuss
Is it possible to create a geodatabase replica with just one layer? It would be helpful to speed up the sync task if we were to only create a replica for the "Trees" [layer](https://services2.arcgis.com/ZQgQTuoyBrtmoGdP/ArcGIS/rest/services/Mobile_Data_Collection_WFL1/FeatureServer/0). 

I tried the following implementation, but the task fails with an error: 
```kotlin
defaultParameters.layerOptions.add(GenerateLayerOption(layerId = 0))
```
Error:
```log
Error fetching geodatabase: Service error code 500: Unable to create replica. Please check your parameters.
Details:
Error in creating runtime geodatabase.
```


