### PR TITLE
show bottom sheet only when directions list is not empty

### DIFF
--- a/find-route-around-barriers/src/main/java/com/esri/arcgismaps/sample/findroutearoundbarriers/MainActivity.kt
+++ b/find-route-around-barriers/src/main/java/com/esri/arcgismaps/sample/findroutearoundbarriers/MainActivity.kt
@@ -219,6 +219,7 @@ class MainActivity : AppCompatActivity() {
 
         // display the bottom sheet with directions when the button is clicked
         directionsButton.setOnClickListener {
+            if (directionsList.isEmpty()) return@setOnClickListener
             setupBottomSheet(directionsList)
         }
 

--- a/find-route-around-barriers/src/main/java/com/esri/arcgismaps/sample/findroutearoundbarriers/MainActivity.kt
+++ b/find-route-around-barriers/src/main/java/com/esri/arcgismaps/sample/findroutearoundbarriers/MainActivity.kt
@@ -219,7 +219,7 @@ class MainActivity : AppCompatActivity() {
 
         // display the bottom sheet with directions when the button is clicked
         directionsButton.setOnClickListener {
-            if (directionsList.isEmpty()) return@setOnClickListener
+            if (directionsList.isEmpty()) return@setOnClickListener showError("Add stops on map to find route")
             setupBottomSheet(directionsList)
         }
 


### PR DESCRIPTION
## Description

PR to fix issue `runtime/kotlin/issues/2228`
The sample should inflate the bottom sheet with directions for at least two stops added to the map. 

But the sample seems to be displaying the sheet, even if stops are not added to the map.

Fix: the `directionsList` is created when 2 or more stops are added on the map. The directions sheet should only show up when the `directionsList` is not empty. 


## How to Test

Run the sample on the sample viewer or the repo.
