### PR TITLE
update sample categories

### DIFF
--- a/browse-building-floors/README.metadata.json
+++ b/browse-building-floors/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "MapViews, SceneViews and UI",
+    "category": "Maps",
     "description": "Display and browse through building floors from a floor-aware web map.",
     "formal_name": "BrowseBuildingFloors",
     "ignore": false,

--- a/change-camera-controller/README.metadata.json
+++ b/change-camera-controller/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "MapViews, SceneViews and UI",
+    "category": "Scenes",
     "description": "Control the behavior of the camera in a scene.",
     "formal_name": "ChangeCameraController",
     "ignore": false,

--- a/change-viewpoint/README.metadata.json
+++ b/change-viewpoint/README.metadata.json
@@ -1,5 +1,5 @@
 {
-  "category": "MapViews, SceneViews and UI",
+  "category": "Maps",
   "description": "Set the map view to a new viewpoint.",
   "formal_name": "ChangeViewpoint",
   "ignore": false,

--- a/display-composable-mapview/README.metadata.json
+++ b/display-composable-mapview/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "Maps and Scenes",
+    "category": "Maps",
     "description": "Display a map using Jetpack Compose.",
     "formal_name": "DisplayComposableMapview",
     "ignore": false,

--- a/display-device-location-with-nmea-data-sources/README.metadata.json
+++ b/display-device-location-with-nmea-data-sources/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "Maps and Scenes",
+    "category": "Maps",
     "description": "This sample demonstrates how to parse NMEA sentences and use the results to show device location on the map.",
     "formal_name": "DisplayDeviceLocationWithNmeaDataSources",
     "ignore": false,

--- a/display-map/README.metadata.json
+++ b/display-map/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "Maps and Scenes",
+    "category": "Maps",
     "description": "Display a map with an imagery basemap.",
     "formal_name": "DisplayMap",
     "ignore": false,

--- a/display-scene/README.metadata.json
+++ b/display-scene/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "Maps and Scenes",
+    "category": "Scenes",
     "description": "Display a scene with a terrain surface and some imagery.",
     "formal_name": "DisplayScene",
     "ignore": false,

--- a/manage-operational-layers/README.metadata.json
+++ b/manage-operational-layers/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "Maps and Scenes",
+    "category": "Maps",
     "description": "Add, remove, and reorder operational layers in a map.",
     "formal_name": "ManageOperationalLayers",
     "ignore": false,

--- a/set-max-extent/README.metadata.json
+++ b/set-max-extent/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "Maps and Scenes",
+    "category": "Maps",
     "description": "Limit the view of a map to a particular area.",
     "formal_name": "SetMaxExtent",
     "ignore": false,

--- a/set-up-location-driven-geotriggers/README.metadata.json
+++ b/set-up-location-driven-geotriggers/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "Maps and Scenes",
+    "category": "Maps",
     "description": "Create a notification every time a given location data source has entered and/or exited a set of features or graphics.",
     "formal_name": "SetUpLocationDrivenGeotriggers",
     "ignore": false,

--- a/set-viewpoint-rotation/README.metadata.json
+++ b/set-viewpoint-rotation/README.metadata.json
@@ -1,5 +1,5 @@
 {
-  "category": "MapViews, SceneViews and UI",
+  "category": "Maps",
   "description": "Rotate a map.",
   "formal_name": "SetViewpointRotation",
   "ignore": false,

--- a/show-device-location-using-indoor-positioning/README.metadata.json
+++ b/show-device-location-using-indoor-positioning/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "Maps and Scenes",
+    "category": "Maps",
     "description": "Show your device's real-time location while inside a building by using signals from indoor positioning beacons.",
     "formal_name": "ShowDeviceLocationUsingIndoorPositioning",
     "ignore": false,

--- a/show-device-location/README.metadata.json
+++ b/show-device-location/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "MapViews, SceneViews and UI",
+    "category": "Maps",
     "description": "Show your current position on the map, as well as switch between different types of auto pan modes.",
     "formal_name": "ShowDeviceLocation",
     "ignore": false,

--- a/show-grid/README.metadata.json
+++ b/show-grid/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "MapViews, SceneViews and UI",
+    "category": "Maps",
     "description": "Display coordinate system grids including Latitude/Longitude, MGRS, UTM and USNG on a map view. Also, toggle label visibility and change the color of grid lines and grid labels.",
     "formal_name": "ShowGrid",
     "ignore": false,

--- a/show-location-history/README.metadata.json
+++ b/show-location-history/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "Maps and Scenes",
+    "category": "Maps",
     "description": "Display your location history on the map.",
     "formal_name": "ShowLocationHistory",
     "ignore": false,

--- a/show-magnifier/README.metadata.json
+++ b/show-magnifier/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "MapViews, SceneViews and UI",
+    "category": "Maps",
     "description": "Tap and hold on a map to show a magnifier.",
     "formal_name": "ShowMagnifier",
     "ignore": false,

--- a/sketch-on-map/README.metadata.json
+++ b/sketch-on-map/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "Maps and Scenes",
+    "category": "Maps",
     "description": "Use the Sketch Editor to edit or sketch a new point, line, or polygon geometry on to a map.",
     "formal_name": "SketchOnMap",
     "ignore": false,

--- a/version.gradle
+++ b/version.gradle
@@ -1,6 +1,6 @@
 ext {
     // ArcGIS Maps SDK for Kotlin version
-    arcgisVersion = '200.2.0-3931'
+    arcgisVersion = '200.2.0-3946'
     // SDK versions
     compileSdkVersion = 33
     minSdkVersion = 26


### PR DESCRIPTION
## Description

PR to update sample categories:
This issue is to update the relevant samples to their respective category names and update the sample viewer to the new category name changes

- [ ] Update the category names in the `metadata.json` on a case-by-case basis for each sample
- [ ] Update sample viewer category names to replace `&` with `and`, for example: `Cloud & Portal` -> `Cloud and Portal`
- [ ] Remove `MapViews, SceneViews & UI` and `Maps & Scenes` from the SV -> Add new categories `Maps` and `Scenes`


## Links and Data

Sample Epic: `runtime/kotlin/issues/2748`

## How to Test

Run the sample on the sample viewer or the repo.

<!-- OPTIONAL
## To Discuss
-->

<!-- OPTIONAL
## Screenshots
-->
