### PR TITLE
IPS sample fix

### DIFF
--- a/show-device-location-using-indoor-positioning/src/main/java/com/esri/arcgismaps/sample/showdevicelocationusingindoorpositioning/MainActivity.kt
+++ b/show-device-location-using-indoor-positioning/src/main/java/com/esri/arcgismaps/sample/showdevicelocationusingindoorpositioning/MainActivity.kt
@@ -140,15 +140,19 @@ class MainActivity : AppCompatActivity() {
     private suspend fun setUpLoadTables(featureTables: MutableList<FeatureTable>) {
         featureTables.forEach { featureTable ->
             // load each FeatureTable
-            featureTable.load().onSuccess {
-                // IPS_Positioning table needs to be present
-                if (featureTable.tableName == "ips_positioning") {
-                    setupIndoorsLocationDataSource(featureTable)
-                }
-            }.onFailure {
+            featureTable.load().onFailure {
                 showError("Error loading FeatureTable: ${it.message}")
             }
         }
+        // retrieve the loaded feature tables
+        featureTables.forEach{ featureTable ->
+            // ips_positioning table needs to be present
+            if (featureTable.tableName == "ips_positioning") {
+                 return setupIndoorsLocationDataSource(featureTable)
+            }
+        }
+        // ips_positioning table not found
+        showError("Positioning Table not found in FeatureTables")
     }
 
     /**

--- a/show-device-location-using-indoor-positioning/src/main/java/com/esri/arcgismaps/sample/showdevicelocationusingindoorpositioning/MainActivity.kt
+++ b/show-device-location-using-indoor-positioning/src/main/java/com/esri/arcgismaps/sample/showdevicelocationusingindoorpositioning/MainActivity.kt
@@ -142,10 +142,8 @@ class MainActivity : AppCompatActivity() {
             // load each FeatureTable
             featureTable.load().onSuccess {
                 // IPS_Positioning table needs to be present
-                if (featureTable.tableName == "IPS_Positioning") {
+                if (featureTable.tableName == "ips_positioning") {
                     setupIndoorsLocationDataSource(featureTable)
-                } else {
-                    showError("Positioning Table not found in FeatureTables")
                 }
             }.onFailure {
                 showError("Error loading FeatureTable: ${it.message}")


### PR DESCRIPTION
## Description
The data source used in the sample has been modified and there are two tables in the currently used [portal item](https://www.arcgis.com/home/item.html?id=8fa941613b4b4b2b8a34ad4cdc3e4bba) (previously it was 1). The feature table used in this sample updated the name from: 
- `IPS_Positioning` -> `ips_positioning`

## Links and Data
Sample issue: `runtime/kotlin/issues/2823`
