### PR TITLE
fix sample viewer build "Visualization" category crash

### DIFF
--- a/display-points-using-clustering-feature-reduction/README.metadata.json
+++ b/display-points-using-clustering-feature-reduction/README.metadata.json
@@ -4,8 +4,8 @@
     "formal_name": "DisplayPointsUsingClusteringFeatureReduction",
     "ignore": false,
     "images": [
-        "display-points-using-clustering-feature-reduction-popup.png",
-        "display-points-using-clustering-feature-reduction.png"
+        "display-points-using-clustering-feature-reduction.png",
+        "display-points-using-clustering-feature-reduction-popup.png"
     ],
     "keywords": [
         "aggregate",


### PR DESCRIPTION
[Sample viewer build sample category crash](https://devtopia.esri.com/runtime/kotlin/issues/2926#issuecomment-4363153):
Fixes an error with sample viewer build caused by the feature reduction metadata file, with the order of the images file names.
Ran the sample viewer app, with this change to verify, and the Visualization category doesnt crash anymore.