### PR TITLE
Foreground service type patch - v.next

### DIFF
--- a/generate-offline-map-using-android-jetpack-workmanager/src/main/AndroidManifest.xml
+++ b/generate-offline-map-using-android-jetpack-workmanager/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 
     <application
         android:allowBackup="true"
@@ -20,6 +21,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="dataSync" />
         <receiver android:name=".NotificationActionReceiver"/>
     </application>
 

--- a/generate-offline-map-using-android-jetpack-workmanager/src/main/java/com/esri/arcgismaps/sample/generateofflinemapusingandroidjetpackworkmanager/OfflineJobWorker.kt
+++ b/generate-offline-map-using-android-jetpack-workmanager/src/main/java/com/esri/arcgismaps/sample/generateofflinemapusingandroidjetpackworkmanager/OfflineJobWorker.kt
@@ -18,6 +18,8 @@
 package com.esri.arcgismaps.sample.generateofflinemapusingandroidjetpackworkmanager
 
 import android.content.Context
+import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+import android.os.Build
 import android.util.Log
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
@@ -59,10 +61,18 @@ class OfflineJobWorker(private val context: Context, params: WorkerParameters) :
      */
     private fun createForegroundInfo(progress: Int): ForegroundInfo {
         // create a ForegroundInfo using the notificationId and a new progress notification
-        return ForegroundInfo(
-            notificationId,
-            workerNotification.createProgressNotification(progress)
-        )
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ForegroundInfo(
+                notificationId,
+                workerNotification.createProgressNotification(progress),
+                FOREGROUND_SERVICE_TYPE_DATA_SYNC
+            )
+        } else {
+            ForegroundInfo(
+                notificationId,
+                workerNotification.createProgressNotification(progress)
+            )
+        }
     }
 
     override suspend fun doWork(): Result {


### PR DESCRIPTION
## Description

PR to fix the crashing of sample `generate-offline-map-using-android-jetpack-workmanager` when running on Android 14 (API level 34) devices.

## Links and Data

#3463

## What To Review

- The correct ForegroundServiceType is used. View all available type [here](https://developer.android.com/develop/background-work/services/fg-service-types#data-sync).
- Sample `generate-offline-map-using-android-jetpack-workmanager` is running on both Android 13 and 14 devices, and the job can execute as expected.

## How to Test

Run the sample on the sample viewer or the repo.
