### PR TITLE
Rename geo-compose -> geoview-compose

### DIFF
--- a/add-dynamic-entity-layer/README.md
+++ b/add-dynamic-entity-layer/README.md
@@ -38,9 +38,9 @@ This sample uses a [stream service](https://realtimegis2016.esri.com:6443/arcgis
 
 ## Additional information
 
-This sample uses the GeoCompose Toolkit module to be able to implement a Composable MapView.
+This sample uses the GeoViewCompose Toolkit module to be able to implement a Composable MapView.
 More information about dynamic entities can be found in the [guide documentation](https://developers.arcgis.com/kotlin/real-time/work-with-dynamic-entities/).
 
 ## Tags
 
-data, dynamic, entity, geocompose, live, purge, real-time, service, stream, toolkit, track
+data, dynamic, entity, geoviewcompose, live, purge, real-time, service, stream, toolkit, track

--- a/add-dynamic-entity-layer/README.metadata.json
+++ b/add-dynamic-entity-layer/README.metadata.json
@@ -10,7 +10,7 @@
         "data",
         "dynamic",
         "entity",
-        "geocompose",
+        "geoviewcompose",
         "live",
         "purge",
         "real-time",

--- a/add-dynamic-entity-layer/build.gradle.kts
+++ b/add-dynamic-entity-layer/build.gradle.kts
@@ -50,5 +50,5 @@ dependencies {
     implementation(project(":samples-lib"))
     // Toolkit dependencies
     implementation(platform(libs.arcgis.maps.kotlin.toolkit.bom))
-    implementation(libs.arcgis.maps.kotlin.toolkit.geo.compose)
+    implementation(libs.arcgis.maps.kotlin.toolkit.geoview.compose)
 }

--- a/add-dynamic-entity-layer/src/main/java/com/esri/arcgismaps/sample/adddynamicentitylayer/screens/MainScreen.kt
+++ b/add-dynamic-entity-layer/src/main/java/com/esri/arcgismaps/sample/adddynamicentitylayer/screens/MainScreen.kt
@@ -36,7 +36,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import com.arcgismaps.toolkit.geocompose.MapView
+import com.arcgismaps.toolkit.geoviewcompose.MapView
 import com.esri.arcgismaps.sample.adddynamicentitylayer.components.DynamicEntityLayerProperties
 import com.esri.arcgismaps.sample.adddynamicentitylayer.components.MapViewModel
 import com.esri.arcgismaps.sample.sampleslib.components.BottomSheet

--- a/analyze-hotspots/README.md
+++ b/analyze-hotspots/README.md
@@ -30,8 +30,8 @@ Tap on Analyze, and select a date from the "FROM" DatePicker and "TO" DatePicker
 
 ## Additional information
 
-This sample uses the GeoCompose Toolkit module to be able to implement a Composable MapView.
+This sample uses the GeoViewCompose Toolkit module to be able to implement a Composable MapView.
 
 ## Tags
 
-analysis, density, geocompose, geoprocessing, hot spots, hotspots, toolkit
+analysis, density, geoviewcompose, geoprocessing, hot spots, hotspots, toolkit

--- a/analyze-hotspots/README.md
+++ b/analyze-hotspots/README.md
@@ -34,4 +34,4 @@ This sample uses the GeoViewCompose Toolkit module to be able to implement a Com
 
 ## Tags
 
-analysis, density, geoviewcompose, geoprocessing, hot spots, hotspots, toolkit
+analysis, density, geoprocessing, geoviewcompose, hot spots, hotspots, toolkit

--- a/analyze-hotspots/README.metadata.json
+++ b/analyze-hotspots/README.metadata.json
@@ -9,8 +9,8 @@
     "keywords": [
         "analysis",
         "density",
-        "geoviewcompose",
         "geoprocessing",
+        "geoviewcompose",
         "hot spots",
         "hotspots",
         "toolkit",

--- a/analyze-hotspots/README.metadata.json
+++ b/analyze-hotspots/README.metadata.json
@@ -9,7 +9,7 @@
     "keywords": [
         "analysis",
         "density",
-        "geocompose",
+        "geoviewcompose",
         "geoprocessing",
         "hot spots",
         "hotspots",

--- a/analyze-hotspots/build.gradle.kts
+++ b/analyze-hotspots/build.gradle.kts
@@ -50,5 +50,5 @@ dependencies {
     implementation(project(":samples-lib"))
     // Toolkit dependencies
     implementation(platform(libs.arcgis.maps.kotlin.toolkit.bom))
-    implementation(libs.arcgis.maps.kotlin.toolkit.geo.compose)
+    implementation(libs.arcgis.maps.kotlin.toolkit.geoview.compose)
 }

--- a/analyze-hotspots/src/main/java/com/esri/arcgismaps/sample/analyzehotspots/screens/MainScreen.kt
+++ b/analyze-hotspots/src/main/java/com/esri/arcgismaps/sample/analyzehotspots/screens/MainScreen.kt
@@ -26,7 +26,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import com.arcgismaps.toolkit.geocompose.MapView
+import com.arcgismaps.toolkit.geoviewcompose.MapView
 import com.esri.arcgismaps.sample.analyzehotspots.components.MapViewModel
 import com.esri.arcgismaps.sample.sampleslib.components.JobLoadingDialog
 import com.esri.arcgismaps.sample.sampleslib.components.MessageDialog

--- a/display-composable-mapview/README.md
+++ b/display-composable-mapview/README.md
@@ -29,8 +29,8 @@ Run the sample to view the map. Pan and zoom to navigate the map.
 
 ## Additional information
 
-This sample uses the GeoCompose Toolkit module to be able to implement a Composable MapView.
+This sample uses the GeoViewCompose Toolkit module to be able to implement a Composable MapView.
 
 ## Tags
 
-basemap, compose, geocompose, jetpack, map, toolkit
+basemap, compose, geoviewcompose, jetpack, map, toolkit

--- a/display-composable-mapview/README.metadata.json
+++ b/display-composable-mapview/README.metadata.json
@@ -9,7 +9,7 @@
     "keywords": [
         "basemap",
         "compose",
-        "geocompose",
+        "geoviewcompose",
         "jetpack",
         "map",
         "toolkit",

--- a/display-composable-mapview/build.gradle.kts
+++ b/display-composable-mapview/build.gradle.kts
@@ -50,5 +50,5 @@ dependencies {
     implementation(project(":samples-lib"))
     // Toolkit dependencies
     implementation(platform(libs.arcgis.maps.kotlin.toolkit.bom))
-    implementation(libs.arcgis.maps.kotlin.toolkit.geo.compose)
+    implementation(libs.arcgis.maps.kotlin.toolkit.geoview.compose)
 }

--- a/display-composable-mapview/src/main/java/com/esri/arcgismaps/sample/displaycomposablemapview/MainActivity.kt
+++ b/display-composable-mapview/src/main/java/com/esri/arcgismaps/sample/displaycomposablemapview/MainActivity.kt
@@ -28,7 +28,7 @@ import com.arcgismaps.ApiKey
 import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.mapping.ArcGISMap
 import com.arcgismaps.mapping.BasemapStyle
-import com.arcgismaps.toolkit.geocompose.MapView
+import com.arcgismaps.toolkit.geoviewcompose.MapView
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 
 class MainActivity : ComponentActivity() {

--- a/display-points-using-clustering-feature-reduction/README.md
+++ b/display-points-using-clustering-feature-reduction/README.md
@@ -42,8 +42,8 @@ This sample uses a [web map](https://www.arcgis.com/home/item.html?id=8916d50c44
 
 ## Additional information
 
-This sample uses the GeoCompose Toolkit module to be able to implement a Composable MapView.
+This sample uses the GeoViewCompose Toolkit module to be able to implement a Composable MapView.
 
 ## Tags
 
-aggregate, bin, cluster, geocompose, group, merge, normalize, reduce, summarize, toolkit
+aggregate, bin, cluster, geoviewcompose, group, merge, normalize, reduce, summarize, toolkit

--- a/display-points-using-clustering-feature-reduction/README.metadata.json
+++ b/display-points-using-clustering-feature-reduction/README.metadata.json
@@ -11,7 +11,7 @@
         "aggregate",
         "bin",
         "cluster",
-        "geocompose",
+        "geoviewcompose",
         "group",
         "merge",
         "normalize",

--- a/display-points-using-clustering-feature-reduction/build.gradle.kts
+++ b/display-points-using-clustering-feature-reduction/build.gradle.kts
@@ -50,5 +50,5 @@ dependencies {
     implementation(project(":samples-lib"))
     // Toolkit dependencies
     implementation(platform(libs.arcgis.maps.kotlin.toolkit.bom))
-    implementation(libs.arcgis.maps.kotlin.toolkit.geo.compose)
+    implementation(libs.arcgis.maps.kotlin.toolkit.geoview.compose)
 }

--- a/display-points-using-clustering-feature-reduction/src/main/java/com/esri/arcgismaps/sample/displaypointsusingclusteringfeaturereduction/components/MapViewModel.kt
+++ b/display-points-using-clustering-feature-reduction/src/main/java/com/esri/arcgismaps/sample/displaypointsusingclusteringfeaturereduction/components/MapViewModel.kt
@@ -45,7 +45,7 @@ import com.arcgismaps.mapping.popup.TextPopupElement
 import com.arcgismaps.mapping.view.IdentifyLayerResult
 import com.arcgismaps.mapping.view.SingleTapConfirmedEvent
 import com.arcgismaps.portal.Portal
-import com.arcgismaps.toolkit.geocompose.MapViewProxy
+import com.arcgismaps.toolkit.geoviewcompose.MapViewProxy
 import com.esri.arcgismaps.sample.displaypointsusingclusteringfeaturereduction.R
 import com.esri.arcgismaps.sample.sampleslib.components.MessageDialogViewModel
 import kotlinx.coroutines.CoroutineScope

--- a/display-points-using-clustering-feature-reduction/src/main/java/com/esri/arcgismaps/sample/displaypointsusingclusteringfeaturereduction/screens/MainScreen.kt
+++ b/display-points-using-clustering-feature-reduction/src/main/java/com/esri/arcgismaps/sample/displaypointsusingclusteringfeaturereduction/screens/MainScreen.kt
@@ -33,7 +33,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import com.arcgismaps.toolkit.geocompose.MapView
+import com.arcgismaps.toolkit.geoviewcompose.MapView
 import com.esri.arcgismaps.sample.displaypointsusingclusteringfeaturereduction.components.ClusterInfoContent
 import com.esri.arcgismaps.sample.displaypointsusingclusteringfeaturereduction.components.MapViewModel
 import com.esri.arcgismaps.sample.sampleslib.components.BottomSheet

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # ArcGIS Maps SDK for Kotlin version
 arcgisMapsKotlinVersion = "200.4.0-4122"
 # ArcGIS Maps SDK for Kotlin Toolkit version
-arcgisToolkitVersion = "200.4.0-2"
+arcgisToolkitVersion = "200.4.0-4183"
 # SDK versions
 compileSdk = "34"
 minSdk = "26"
@@ -60,6 +60,6 @@ androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx"
 arcgis-maps-kotlin = { group = "com.esri", name = "arcgis-maps-kotlin", version.ref = "arcgisMapsKotlinVersion"}
 arcgis-maps-kotlin-toolkit-bom = { group = "com.esri", name = "arcgis-maps-kotlin-toolkit-bom", version.ref = "arcgisToolkitVersion"}
 arcgis-maps-kotlin-toolkit-authentication = { group = "com.esri", name = "arcgis-maps-kotlin-toolkit-authentication" }
-arcgis-maps-kotlin-toolkit-geo-compose = { group = "com.esri", name = "arcgis-maps-kotlin-toolkit-geo-compose" }
+arcgis-maps-kotlin-toolkit-geoview-compose = { group = "com.esri", name = "arcgis-maps-kotlin-toolkit-geoview-compose" }
 commons-io = { group = "commons-io", name = "commons-io", version.ref = "commonsIoVersion" }
 stdlib-jdk8 = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib-jdk8", version.ref = "kotlinVersion"}

--- a/identify-layer-features/README.md
+++ b/identify-layer-features/README.md
@@ -26,9 +26,9 @@ Tap to identify features. A bottom text banner will show all layers with feature
 
 ## Additional information
 
-This sample uses the GeoCompose Toolkit module to be able to implement a Composable MapView.
+This sample uses the GeoViewCompose Toolkit module to be able to implement a Composable MapView.
 The GeoView supports two methods of identify: `identifyLayer`, which identifies features within a specific layer and `identifyLayers`, which identifies features for all layers in the current view.
 
 ## Tags
 
-geocompose, identify, recursion, recursive, sublayers, toolkit
+geoviewcompose, identify, recursion, recursive, sublayers, toolkit

--- a/identify-layer-features/README.metadata.json
+++ b/identify-layer-features/README.metadata.json
@@ -7,7 +7,7 @@
         "identify-layer-features.png"
     ],
     "keywords": [
-        "geocompose",
+        "geoviewcompose",
         "identify",
         "recursion",
         "recursive",

--- a/identify-layer-features/build.gradle.kts
+++ b/identify-layer-features/build.gradle.kts
@@ -50,5 +50,5 @@ dependencies {
     implementation(project(":samples-lib"))
     // Toolkit dependencies
     implementation(platform(libs.arcgis.maps.kotlin.toolkit.bom))
-    implementation(libs.arcgis.maps.kotlin.toolkit.geo.compose)
+    implementation(libs.arcgis.maps.kotlin.toolkit.geoview.compose)
 }

--- a/identify-layer-features/src/main/java/com/esri/arcgismaps/sample/identifylayerfeatures/components/MapViewModel.kt
+++ b/identify-layer-features/src/main/java/com/esri/arcgismaps/sample/identifylayerfeatures/components/MapViewModel.kt
@@ -28,7 +28,7 @@ import com.arcgismaps.mapping.layers.ArcGISMapImageLayer
 import com.arcgismaps.mapping.layers.FeatureLayer.Companion.createWithFeatureTable
 import com.arcgismaps.mapping.view.IdentifyLayerResult
 import com.arcgismaps.mapping.view.SingleTapConfirmedEvent
-import com.arcgismaps.toolkit.geocompose.MapViewProxy
+import com.arcgismaps.toolkit.geoviewcompose.MapViewProxy
 import com.esri.arcgismaps.sample.identifylayerfeatures.R
 import com.esri.arcgismaps.sample.sampleslib.components.MessageDialogViewModel
 import kotlinx.coroutines.CoroutineScope

--- a/identify-layer-features/src/main/java/com/esri/arcgismaps/sample/identifylayerfeatures/screens/MainScreen.kt
+++ b/identify-layer-features/src/main/java/com/esri/arcgismaps/sample/identifylayerfeatures/screens/MainScreen.kt
@@ -31,7 +31,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import com.arcgismaps.toolkit.geocompose.MapView
+import com.arcgismaps.toolkit.geoviewcompose.MapView
 import com.esri.arcgismaps.sample.identifylayerfeatures.components.MapViewModel
 import com.esri.arcgismaps.sample.sampleslib.components.MessageDialog
 import com.esri.arcgismaps.sample.sampleslib.components.SampleTopAppBar

--- a/manage-operational-layers/README.md
+++ b/manage-operational-layers/README.md
@@ -27,9 +27,9 @@ When the app starts, the display lists of operational layers and any removed lay
 
 ## Additional information
 
-This sample uses the GeoCompose Toolkit module to be able to implement a Composable MapView.
+This sample uses the GeoViewCompose Toolkit module to be able to implement a Composable MapView.
 You cannot add the same layer to the map multiple times or add the same layer to multiple maps. Instead, clone the layer with `layer.clone()` before duplicating.
 
 ## Tags
 
-add, delete, geocompose, layer, map, remove, toolkit
+add, delete, geoviewcompose, layer, map, remove, toolkit

--- a/manage-operational-layers/README.metadata.json
+++ b/manage-operational-layers/README.metadata.json
@@ -9,7 +9,7 @@
     "keywords": [
         "add",
         "delete",
-        "geocompose",
+        "geoviewcompose",
         "layer",
         "map",
         "remove",

--- a/manage-operational-layers/build.gradle.kts
+++ b/manage-operational-layers/build.gradle.kts
@@ -50,5 +50,5 @@ dependencies {
     implementation(project(":samples-lib"))
     // Toolkit dependencies
     implementation(platform(libs.arcgis.maps.kotlin.toolkit.bom))
-    implementation(libs.arcgis.maps.kotlin.toolkit.geo.compose)
+    implementation(libs.arcgis.maps.kotlin.toolkit.geoview.compose)
 }

--- a/manage-operational-layers/src/main/java/com/esri/arcgismaps/sample/manageoperationallayers/screens/MainScreen.kt
+++ b/manage-operational-layers/src/main/java/com/esri/arcgismaps/sample/manageoperationallayers/screens/MainScreen.kt
@@ -24,7 +24,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import com.arcgismaps.toolkit.geocompose.MapView
+import com.arcgismaps.toolkit.geoviewcompose.MapView
 import com.esri.arcgismaps.sample.manageoperationallayers.components.MapViewModel
 import com.esri.arcgismaps.sample.sampleslib.components.SampleTopAppBar
 

--- a/query-feature-table/README.md
+++ b/query-feature-table/README.md
@@ -32,8 +32,8 @@ This sample uses U.S. State polygon features from the [USA 2016 Daytime Populati
 
 ## Additional information
 
-This sample uses the GeoCompose Toolkit module to be able to implement a Composable MapView.
+This sample uses the GeoViewCompose Toolkit module to be able to implement a Composable MapView.
 
 ## Tags
 
-geocompose, query, search, toolkit
+geoviewcompose, query, search, toolkit

--- a/query-feature-table/README.metadata.json
+++ b/query-feature-table/README.metadata.json
@@ -7,7 +7,7 @@
         "query-feature-table.png"
     ],
     "keywords": [
-        "geocompose",
+        "geoviewcompose",
         "query",
         "search",
         "toolkit",

--- a/query-feature-table/build.gradle.kts
+++ b/query-feature-table/build.gradle.kts
@@ -50,5 +50,5 @@ dependencies {
     implementation(project(":samples-lib"))
     // Toolkit dependencies
     implementation(platform(libs.arcgis.maps.kotlin.toolkit.bom))
-    implementation(libs.arcgis.maps.kotlin.toolkit.geo.compose)
+    implementation(libs.arcgis.maps.kotlin.toolkit.geoview.compose)
 }

--- a/query-feature-table/src/main/java/com/esri/arcgismaps/sample/queryfeaturetable/components/MapViewModel.kt
+++ b/query-feature-table/src/main/java/com/esri/arcgismaps/sample/queryfeaturetable/components/MapViewModel.kt
@@ -36,7 +36,7 @@ import com.arcgismaps.mapping.symbology.SimpleFillSymbolStyle
 import com.arcgismaps.mapping.symbology.SimpleLineSymbol
 import com.arcgismaps.mapping.symbology.SimpleLineSymbolStyle
 import com.arcgismaps.mapping.symbology.SimpleRenderer
-import com.arcgismaps.toolkit.geocompose.MapViewProxy
+import com.arcgismaps.toolkit.geoviewcompose.MapViewProxy
 import com.esri.arcgismaps.sample.queryfeaturetable.R
 import com.esri.arcgismaps.sample.sampleslib.components.MessageDialogViewModel
 import kotlinx.coroutines.CoroutineScope

--- a/query-feature-table/src/main/java/com/esri/arcgismaps/sample/queryfeaturetable/screens/MainScreen.kt
+++ b/query-feature-table/src/main/java/com/esri/arcgismaps/sample/queryfeaturetable/screens/MainScreen.kt
@@ -27,7 +27,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import com.arcgismaps.toolkit.geocompose.MapView
+import com.arcgismaps.toolkit.geoviewcompose.MapView
 import com.esri.arcgismaps.sample.queryfeaturetable.components.MapViewModel
 import com.esri.arcgismaps.sample.sampleslib.components.MessageDialog
 import com.esri.arcgismaps.sample.sampleslib.components.SampleTopAppBar

--- a/show-coordinates-in-multiple-formats/README.md
+++ b/show-coordinates-in-multiple-formats/README.md
@@ -26,8 +26,8 @@ Tap on the map to see a marker with the tapped location's coordinate formatted i
 
 ## Additional information
 
-This sample uses the GeoCompose Toolkit module to be able to implement a Composable MapView.
+This sample uses the GeoViewCompose Toolkit module to be able to implement a Composable MapView.
 
 ## Tags
 
-convert, coordinate, decimal degrees, degree minutes seconds, format, geocompose, latitude, longitude, toolkit, USNG, UTM
+convert, coordinate, decimal degrees, degree minutes seconds, format, geoviewcompose, latitude, longitude, toolkit, USNG, UTM

--- a/show-coordinates-in-multiple-formats/README.metadata.json
+++ b/show-coordinates-in-multiple-formats/README.metadata.json
@@ -14,7 +14,7 @@
         "decimal degrees",
         "degree minutes seconds",
         "format",
-        "geocompose",
+        "geoviewcompose",
         "latitude",
         "longitude",
         "toolkit",

--- a/show-coordinates-in-multiple-formats/build.gradle.kts
+++ b/show-coordinates-in-multiple-formats/build.gradle.kts
@@ -50,5 +50,5 @@ dependencies {
     implementation(project(":samples-lib"))
     // Toolkit dependencies
     implementation(platform(libs.arcgis.maps.kotlin.toolkit.bom))
-    implementation(libs.arcgis.maps.kotlin.toolkit.geo.compose)
+    implementation(libs.arcgis.maps.kotlin.toolkit.geoview.compose)
 }

--- a/show-coordinates-in-multiple-formats/src/main/java/com/esri/arcgismaps/sample/showcoordinatesinmultipleformats/screens/MainScreen.kt
+++ b/show-coordinates-in-multiple-formats/src/main/java/com/esri/arcgismaps/sample/showcoordinatesinmultipleformats/screens/MainScreen.kt
@@ -29,7 +29,7 @@ import com.arcgismaps.mapping.ArcGISMap
 import com.arcgismaps.mapping.Basemap
 import com.arcgismaps.mapping.layers.ArcGISTiledLayer
 import com.arcgismaps.mapping.view.GraphicsOverlay
-import com.arcgismaps.toolkit.geocompose.MapView
+import com.arcgismaps.toolkit.geoviewcompose.MapView
 import com.esri.arcgismaps.sample.sampleslib.components.MessageDialog
 import com.esri.arcgismaps.sample.sampleslib.components.SampleTopAppBar
 import com.esri.arcgismaps.sample.showcoordinatesinmultipleformats.R

--- a/show-magnifier/README.md
+++ b/show-magnifier/README.md
@@ -26,9 +26,9 @@ Tap and hold on the map to show a magnifier, then drag across the map to move th
 
 ## Additional information
 
-This sample uses the GeoCompose Toolkit module to be able to implement a Composable MapView.
+This sample uses the GeoViewCompose Toolkit module to be able to implement a Composable MapView.
 It only works on a device with a touch screen. The magnifier will not appear via a mouse click.
 
 ## Tags
 
-geocompose, magnify, map, toolkit, zoom
+geoviewcompose, magnify, map, toolkit, zoom

--- a/show-magnifier/README.metadata.json
+++ b/show-magnifier/README.metadata.json
@@ -7,7 +7,7 @@
         "show-magnifier.png"
     ],
     "keywords": [
-        "geocompose",
+        "geoviewcompose",
         "magnify",
         "map",
         "toolkit",

--- a/show-magnifier/build.gradle.kts
+++ b/show-magnifier/build.gradle.kts
@@ -50,5 +50,5 @@ dependencies {
     implementation(project(":samples-lib"))
     // Toolkit dependencies
     implementation(platform(libs.arcgis.maps.kotlin.toolkit.bom))
-    implementation(libs.arcgis.maps.kotlin.toolkit.geo.compose)
+    implementation(libs.arcgis.maps.kotlin.toolkit.geoview.compose)
 }

--- a/show-magnifier/src/main/java/com/esri/arcgismaps/sample/showmagnifier/screens/MainScreen.kt
+++ b/show-magnifier/src/main/java/com/esri/arcgismaps/sample/showmagnifier/screens/MainScreen.kt
@@ -25,7 +25,7 @@ import com.arcgismaps.mapping.ArcGISMap
 import com.arcgismaps.mapping.BasemapStyle
 import com.arcgismaps.mapping.Viewpoint
 import com.arcgismaps.mapping.view.MapViewInteractionOptions
-import com.arcgismaps.toolkit.geocompose.MapView
+import com.arcgismaps.toolkit.geoviewcompose.MapView
 import com.esri.arcgismaps.sample.sampleslib.components.SampleTopAppBar
 
 /**


### PR DESCRIPTION
## Description

PR to rename geo-compose -> geoview-compose

## Links and Data

Sample Epic: `runtime/kotlin/issues/3653`

## What To Review

- Leaving out the renaming changes in tools/NewModuleScript to Ruiqi, as she will address that in [#3649]
- Review the refactoring changes elsewhere

## How to Test

Run the affected sample on the sample viewer or the repo.


<!-- OPTIONAL
## To Discuss
-->

<!-- OPTIONAL
## Screenshots
-->
