### PR TITLE
Update v.next for next release

### DIFF
--- a/add-dynamic-entity-layer/src/main/java/com/esri/arcgismaps/sample/adddynamicentitylayer/components/BottomSheetContent.kt
+++ b/add-dynamic-entity-layer/src/main/java/com/esri/arcgismaps/sample/adddynamicentitylayer/components/BottomSheetContent.kt
@@ -25,7 +25,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
@@ -99,7 +99,7 @@ fun DynamicEntityLayerProperties(
                         }
                     )
                 }
-                Divider(thickness = 0.5.dp)
+                HorizontalDivider(thickness = 0.5.dp)
                 Row(
                     modifier = Modifier
                         .fillMaxWidth(),
@@ -148,7 +148,7 @@ fun DynamicEntityLayerProperties(
                         valueRange = 1f..16f
                     )
                 }
-                Divider(thickness = 0.5.dp)
+                HorizontalDivider(thickness = 0.5.dp)
                 TextButton(
                     modifier = Modifier.align(CenterHorizontally),
                     onClick = onPurgeAllObservations

--- a/authenticate-with-oauth/src/main/java/com/esri/arcgismaps/sample/authenticatewithoauth/OAuthUserSignInViewModel.kt
+++ b/authenticate-with-oauth/src/main/java/com/esri/arcgismaps/sample/authenticatewithoauth/OAuthUserSignInViewModel.kt
@@ -56,7 +56,7 @@ class OAuthUserSignInViewModel(
 
     fun promptForOAuthUserSignIn(oAuthUserSignIn: OAuthUserSignIn) {
         pendingSignIn = oAuthUserSignIn
-        oAuthLauncher.launch(pendingSignIn)
+        oAuthLauncher.launch(pendingSignIn!!)
     }
 
     private fun complete(redirectUri: String?) {

--- a/display-clusters/src/main/java/com/esri/arcgismaps/sample/displayclusters/components/ClusterInfoContent.kt
+++ b/display-clusters/src/main/java/com/esri/arcgismaps/sample/displayclusters/components/ClusterInfoContent.kt
@@ -27,7 +27,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Close
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -74,7 +74,7 @@ fun ClusterInfoContent(
 
         LazyColumn {
             items(clusterInfoList.size) { index ->
-                Divider(
+                HorizontalDivider(
                     modifier = Modifier.padding(horizontal = 12.dp),
                     color = Color.LightGray
                 )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,26 +10,26 @@ targetSdk = "34"
 versionCode = "2004000"
 versionName = "200.4.0"
 # Kotlin versions
-kotlinVersion = "1.9.21"
-ktxLifecycle = "2.6.2"
+kotlinVersion = "1.9.23"
+ktxLifecycle = "2.7.0"
 ktxFragmentsExt = "1.6.2"
 ktxActivityExt = "1.8.2"
 ktxAndroidCore = "1.12.0"
-kotlinCompilerExt = "1.5.6"
+kotlinCompilerExt = "1.5.11"
 # Compose versions
-composeActivityVersion = "1.7.1"
-composeBOM = "2023.10.01"
+composeActivityVersion = "1.8.2"
+composeBOM = "2024.04.00"
 # Library versions
 appcompatVersion = "1.6.1"
-commonsIoVersion = "2.11.0"
+commonsIoVersion = "2.15.1"
 constraintLayoutVersion = "2.1.4"
 coordinateLayoutVersion = "1.2.0"
-workVersion = "2.7.1"
+workVersion = "2.9.0"
 multidexVersion = "2.0.1"
-materialVersion = "1.7.0"
-androidBrowserVersion = "1.7.0"
+materialVersion = "1.11.0"
+androidBrowserVersion = "1.8.0"
 # Plugin versions
-gradleVersion = "8.2.0"
+gradleVersion = "8.3.1"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "gradleVersion" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # ArcGIS Maps SDK for Kotlin version
 arcgisMapsKotlinVersion = "200.5.0-4211"
 # ArcGIS Maps SDK for Kotlin Toolkit version
-arcgisToolkitVersion = "200.4.0" ## TODO: Waiting for a successfull build
+arcgisToolkitVersion = "200.5.0-4211"
 # SDK versions
 compileSdk = "34"
 minSdk = "26"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 # ArcGIS Maps SDK for Kotlin version
-arcgisMapsKotlinVersion = "200.4.0"
+arcgisMapsKotlinVersion = "200.5.0-4190"
 # ArcGIS Maps SDK for Kotlin Toolkit version
-arcgisToolkitVersion = "200.4.0"
+arcgisToolkitVersion = "200.5.0-4190"
 # SDK versions
 compileSdk = "34"
 minSdk = "26"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 # ArcGIS Maps SDK for Kotlin version
-arcgisMapsKotlinVersion = "200.5.0-4190"
+arcgisMapsKotlinVersion = "200.5.0-4211"
 # ArcGIS Maps SDK for Kotlin Toolkit version
-arcgisToolkitVersion = "200.5.0-4190"
+arcgisToolkitVersion = "200.4.0" ## TODO: Waiting for a successfull build
 # SDK versions
 compileSdk = "34"
 minSdk = "26"
@@ -13,12 +13,12 @@ versionName = "200.4.0"
 kotlinVersion = "1.9.23"
 ktxLifecycle = "2.7.0"
 ktxFragmentsExt = "1.6.2"
-ktxActivityExt = "1.8.2"
-ktxAndroidCore = "1.12.0"
+ktxActivityExt = "1.9.0"
+ktxAndroidCore = "1.13.0"
 kotlinCompilerExt = "1.5.11"
 # Compose versions
-composeActivityVersion = "1.8.2"
-composeBOM = "2024.04.00"
+composeActivityVersion = "1.9.0"
+composeBOM = "2024.04.01"
 # Library versions
 appcompatVersion = "1.6.1"
 commonsIoVersion = "2.15.1"
@@ -29,7 +29,7 @@ multidexVersion = "2.0.1"
 materialVersion = "1.11.0"
 androidBrowserVersion = "1.8.0"
 # Plugin versions
-gradleVersion = "8.3.1"
+gradleVersion = "8.3.2"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "gradleVersion" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Mar 27 09:39:37 PDT 2024
+#Tue Apr 16 15:17:41 PDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/samples-lib/src/main/java/com/esri/arcgismaps/sample/sampleslib/DownloaderActivity.kt
+++ b/samples-lib/src/main/java/com/esri/arcgismaps/sample/sampleslib/DownloaderActivity.kt
@@ -119,6 +119,7 @@ abstract class DownloaderActivity : AppCompatActivity() {
                 // set up the alert dialog builder
                 val provisionQuestionDialog = MaterialAlertDialogBuilder(this@DownloaderActivity)
                     .setTitle("Download data?")
+                    .setCancelable(false)
 
                 if (provisionFolder.list()?.isNotEmpty() == true) {
                     // folder is not empty, prompt user to download again
@@ -204,6 +205,7 @@ abstract class DownloaderActivity : AppCompatActivity() {
             val dialogView: View = layoutInflater.inflate(R.layout.download_dialog, null)
             val loadingBuilder = MaterialAlertDialogBuilder(this@DownloaderActivity).apply {
                 setView(dialogView)
+                setCancelable(false)
                 create()
             }
             // download progress indicator layout

--- a/samples-lib/src/main/java/com/esri/arcgismaps/sample/sampleslib/components/JobLoadingDialog.kt
+++ b/samples-lib/src/main/java/com/esri/arcgismaps/sample/sampleslib/components/JobLoadingDialog.kt
@@ -26,7 +26,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -44,6 +44,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 
 /**
@@ -59,10 +60,12 @@ fun JobLoadingDialog(
     pauseJobRequest: (Unit) -> Unit = {},
     resumeJobRequest: (Unit) -> Unit = {},
 ) {
-    AlertDialog(
-        onDismissRequest = {
-            // No dismiss allowed, instead use 'Cancel job' button
-        },
+    BasicAlertDialog(
+        properties = DialogProperties(
+            dismissOnBackPress = false,
+            dismissOnClickOutside = false
+        ),
+        onDismissRequest = { /* No dismiss allowed, instead use 'Cancel job' button */ }
     ) {
         Surface(
             tonalElevation = 12.dp,
@@ -89,11 +92,11 @@ fun JobLoadingDialog(
                         animationSpec = tween(
                             durationMillis = 500,
                             easing = FastOutSlowInEasing
-                        )
+                        ), label = "FloatAnimation"
                     )
                     // create the linear progress indicator
                     LinearProgressIndicator(
-                        progress = progressAnimation
+                        progress = { progressAnimation },
                     )
                     // progress percentage text
                     Text(

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,6 +13,7 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         maven { url = uri("https://esri.jfrog.io/artifactory/arcgis") }
+        maven { url = uri("https://olympus.esri.com/artifactory/arcgisruntime-repo/") }
     }
 }
 

--- a/show-device-location-using-indoor-positioning/src/main/java/com/esri/arcgismaps/sample/showdevicelocationusingindoorpositioning/MainActivity.kt
+++ b/show-device-location-using-indoor-positioning/src/main/java/com/esri/arcgismaps/sample/showdevicelocationusingindoorpositioning/MainActivity.kt
@@ -333,7 +333,7 @@ class MainActivity : AppCompatActivity() {
      */
     override fun onRequestPermissionsResult(
         requestCode: Int,
-        permissions: Array<String?>,
+        permissions: Array<String>,
         grantResults: IntArray
     ) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)

--- a/show-portal-user-info/src/main/java/com/esri/arcgismaps/sample/showportaluserinfo/screens/MainScreen.kt
+++ b/show-portal-user-info/src/main/java/com/esri/arcgismaps/sample/showportaluserinfo/screens/MainScreen.kt
@@ -34,7 +34,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -44,7 +44,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.Center
 import androidx.compose.ui.Alignment.Companion.CenterHorizontally
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.asImageBitmap
@@ -118,7 +117,6 @@ fun MainScreen(sampleName: String, application: Application) {
  * It uses OAuth under the hood, and has a button to clear credentials.
  *
  */
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun PortalDetails(
     url: String,
@@ -210,7 +208,7 @@ private fun InfoScreen(
                         text = infoText
                     )
                 }
-                Divider()
+                HorizontalDivider()
                 Row(
                     modifier = Modifier
                         .padding(10.dp)
@@ -226,28 +224,28 @@ private fun InfoScreen(
                             .size(150.dp)
                     )
                 }
-                Divider()
+                HorizontalDivider()
                 Row(modifier = Modifier.padding(10.dp)) {
                     Text(text = "Username: ", fontWeight = FontWeight.Bold)
                     Text(text = username)
                 }
-                Divider()
+                HorizontalDivider()
                 Row(modifier = Modifier.padding(10.dp)) {
                     Text(text = "E-mail: ", fontWeight = FontWeight.Bold)
                     Text(text = email)
                 }
-                Divider()
+                HorizontalDivider()
                 Row(modifier = Modifier.padding(10.dp)) {
                     Text(text = "Member Since: ", fontWeight = FontWeight.Bold)
                     Text(text = creationDate)
                 }
-                Divider()
+                HorizontalDivider()
 
                 Row(modifier = Modifier.padding(10.dp)) {
                     Text(text = "Portal Name: ", fontWeight = FontWeight.Bold)
                     Text(text = portalName)
                 }
-                Divider()
+                HorizontalDivider()
             }
         }
     }


### PR DESCRIPTION
## Description

PR to update the `v.next` branch to start using `200.5.0` daily builds. 


### Changes:
- `Divider` is deprecated, using `HorizontalDivider` instead.
- `AlertDialog` is deprecated, using `BasicAlertDialog ` instead.
- Some changes `LinearProgressIndicator` on the lastest compose version. 
- Updated `DownloaderActivity` and `JobLoadingDialog` to not be cancellable on back press 
