### PR TITLE
Bug: Update searchView query with selected suggestion result

### DIFF
--- a/geocode-offline/src/main/java/com/esri/arcgismaps/sample/geocodeoffline/MainActivity.kt
+++ b/geocode-offline/src/main/java/com/esri/arcgismaps/sample/geocodeoffline/MainActivity.kt
@@ -169,8 +169,7 @@ class MainActivity : AppCompatActivity() {
 
             override fun onSuggestionClick(position: Int): Boolean {
                 // geocode the typed address
-                geocodeAddress(suggestions[position])
-                addressSearchView.clearFocus()
+                addressSearchView.setQuery(suggestions[position], true)
                 return true
             }
         })
@@ -198,7 +197,8 @@ class MainActivity : AppCompatActivity() {
         // load the locator task
         locatorTask.load().getOrThrow()
         // run the locatorTask geocode task, passing in the address
-        val geocodeResults = locatorTask.geocode(address, geocodeParameters).getOrElse {
+        val geocodeResults = locatorTask.geocode(address, geocodeParameters).getOrThrow()
+        geocodeResults.ifEmpty {
             // no address found in geocode so return
             showError("No address found for $address")
             return@launch

--- a/search-with-geocode/src/main/java/com/esri/arcgismaps/sample/searchwithgeocode/MainActivity.kt
+++ b/search-with-geocode/src/main/java/com/esri/arcgismaps/sample/searchwithgeocode/MainActivity.kt
@@ -188,12 +188,12 @@ class MainActivity : AppCompatActivity() {
                                         // get the row's index
                                         val selectedCursorIndex =
                                             selectedRow.getColumnIndex("address")
-                                        // get the string from the row at index
+                                        // get the string from the row at index and set it to query
                                         val selectedAddress =
                                             selectedRow.getString(selectedCursorIndex)
+                                        addressSearchView.setQuery(selectedAddress, false)
                                         // geocode the typed address
                                         geocodeAddress(selectedAddress, false)
-                                        addressSearchView.isIconified = true
                                         addressSearchView.clearAndHideKeyboard()
                                     }
                                     return true


### PR DESCRIPTION
## Description
<!--
PR to add a new Kotlin sample _"SAMPLE_NAME"_ in `SAMPLE_CATEGORY` category.
-->
PR to resolve bug that the textfield is not filled when choosing a text from suggestion list.

## Links and Data
<!--
Sample Epic: `runtime/kotlin/issues/ISSUE_NUMBER`
-->
#3259

## What To Review
<!--
-  Review the code to make sure it is easy to follow like other samples on Android
- `README.md` and `README.metadata.json` files
-->
Sample `search-with-geocode` and `geocode-offline` run well. When selecting from the suggestion list, the selected text is filled in textfield and can search successfully.

## How to Test
<!--
Run the sample on the sample viewer or the repo.
-->
Sample `search-with-geocode` and `geocode-offline` run well.

<!-- OPTIONAL
## To Discuss
-->

<!-- OPTIONAL
## Screenshots
-->
