### PR TITLE
Show line of sight add copyright header

### DIFF
--- a/show-line-of-sight-between-geoelements/src/main/java/com/esri/arcgismaps/sample/showlineofsightbetweengeoelements/DownloadActivity.kt
+++ b/show-line-of-sight-between-geoelements/src/main/java/com/esri/arcgismaps/sample/showlineofsightbetweengeoelements/DownloadActivity.kt
@@ -1,3 +1,19 @@
+/* Copyright 2024 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.esri.arcgismaps.sample.showlineofsightbetweengeoelements
 
 import android.content.Intent


### PR DESCRIPTION
## Description
PR to add a copyright header to `DownloadActivity.kt` in sample `Show-Line-Of-Sight-Between-Geoelements`
## Links and Data
Sample Epic: `runtime/kotlin/issues/ISSUE_NUMBER`
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/
## What To Review
-  `DownloadActivity.kt` to verify that Esri copyright header exists 