### PR TITLE
Fixed issue through adding onLayerViewStatechanged on MapView

### DIFF
--- a/generate-offline-map/src/main/java/com/esri/arcgismaps/sample/generateofflinemap/components/MapViewModel.kt
+++ b/generate-offline-map/src/main/java/com/esri/arcgismaps/sample/generateofflinemap/components/MapViewModel.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.unit.IntSize
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.arcgismaps.geometry.Envelope
-import com.arcgismaps.geometry.SpatialReference
 import com.arcgismaps.mapping.ArcGISMap
 import com.arcgismaps.mapping.PortalItem
 import com.arcgismaps.mapping.symbology.SimpleLineSymbol
@@ -46,8 +45,6 @@ import kotlinx.coroutines.launch
 import java.io.File
 
 class MapViewModel(private val application: Application) : AndroidViewModel(application) {
-
-    var currentSpatialReference by mutableStateOf<SpatialReference?>(null)
 
     // Create a symbol to show a box around the extent we want to download
     private val downloadArea: Graphic = Graphic(
@@ -122,7 +119,6 @@ class MapViewModel(private val application: Application) : AndroidViewModel(appl
                     // Limit the map scale to the largest layer scale
                     map.maxScale = map.operationalLayers[6].maxScale ?: 0.0
                     map.minScale = map.operationalLayers[6].minScale ?: 0.0
-
                 }
         }
     }
@@ -286,6 +282,7 @@ class MapViewModel(private val application: Application) : AndroidViewModel(appl
         val minPoint = mapViewProxy.screenToLocationOrNull(minScreenPoint)
         val maxPoint = mapViewProxy.screenToLocationOrNull(maxScreenPoint)
 
+        // Create an envelope to set the download area's geometry using the defined bounds
         if (minPoint != null && maxPoint != null) {
             val envelope = Envelope(minPoint, maxPoint)
             downloadArea.geometry = envelope

--- a/generate-offline-map/src/main/java/com/esri/arcgismaps/sample/generateofflinemap/screens/MainScreen.kt
+++ b/generate-offline-map/src/main/java/com/esri/arcgismaps/sample/generateofflinemap/screens/MainScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.arcgismaps.LoadStatus
 import com.arcgismaps.toolkit.geoviewcompose.MapView
 import com.esri.arcgismaps.sample.generateofflinemap.R
 import com.esri.arcgismaps.sample.generateofflinemap.components.MapViewModel
@@ -65,14 +66,29 @@ fun MainScreen(sampleName: String) {
                         .fillMaxWidth()
                         // Retrieve the size of the Composable MapView
                         .onSizeChanged { size ->
+                            println("Size: $size")
                             mapViewModel.updateMapViewSize(size)
                         },
                     arcGISMap = mapViewModel.map,
                     graphicsOverlays = listOf(mapViewModel.graphicsOverlay),
                     mapViewProxy = mapViewModel.mapViewProxy,
+                    onLayerViewStateChanged = {
+                        // For Initial Launch
+                        // Ensure the map is fully loaded before calculating the download area
+                        if (mapViewModel.map.loadStatus.value == LoadStatus.Loaded) {
+                            mapViewModel.calculateDownloadOfflineArea()
+                        }
+                    },
                     onViewpointChangedForCenterAndScale = {
-                        mapViewModel.calculateDownloadOfflineArea()
+                        // Ensure the map is fully loaded before calculating the download area
+                        if (mapViewModel.map.loadStatus.value == LoadStatus.Loaded) {
+                            mapViewModel.calculateDownloadOfflineArea()
+                        }
+                    },
+                    onSpatialReferenceChanged = { spatialReference ->
+                        mapViewModel.currentSpatialReference = spatialReference
                     }
+
                 )
 
                 Row(

--- a/generate-offline-map/src/main/java/com/esri/arcgismaps/sample/generateofflinemap/screens/MainScreen.kt
+++ b/generate-offline-map/src/main/java/com/esri/arcgismaps/sample/generateofflinemap/screens/MainScreen.kt
@@ -66,31 +66,25 @@ fun MainScreen(sampleName: String) {
                         .fillMaxWidth()
                         // Retrieve the size of the Composable MapView
                         .onSizeChanged { size ->
-                            println("Size: $size")
                             mapViewModel.updateMapViewSize(size)
                         },
                     arcGISMap = mapViewModel.map,
                     graphicsOverlays = listOf(mapViewModel.graphicsOverlay),
                     mapViewProxy = mapViewModel.mapViewProxy,
                     onLayerViewStateChanged = {
-                        // For Initial Launch
-                        // Ensure the map is fully loaded before calculating the download area
+                        // On launch, ensure the map is loaded before calculating the download area
                         if (mapViewModel.map.loadStatus.value == LoadStatus.Loaded) {
                             mapViewModel.calculateDownloadOfflineArea()
                         }
                     },
                     onViewpointChangedForCenterAndScale = {
-                        // Ensure the map is fully loaded before calculating the download area
+                        // Ensure the map is loaded before calculating the download area
                         if (mapViewModel.map.loadStatus.value == LoadStatus.Loaded) {
                             mapViewModel.calculateDownloadOfflineArea()
                         }
                     },
-                    onSpatialReferenceChanged = { spatialReference ->
-                        mapViewModel.currentSpatialReference = spatialReference
-                    }
 
                 )
-
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()


### PR DESCRIPTION
## Description
PR to fix a Kotlin sample _"GENERATE_OFFLINE_MAP"_ in `EDIT_AND_MANAGE_DATA` category.
## Links and Data
Sample Epic: `runtime/kotlin/issues/ISSUE_NUMBER`
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/
## What To Review
-  Review the changed/added code to make sure the changes wouldn't impact anything else and to see if sample code is easy to read.
- `MainScreen.kt` and `MapViewModel.kt` files

## How to Test
Run the sample on the sample viewer or the repo. 
1. When running it, the red border should always show on launch
2. After generating the offline map, and resettiing the map, the red border should show and stay the same size. 
