### PR TITLE
[Patch] Create and save map

### DIFF
--- a/create-and-save-map/src/main/java/com/esri/arcgismaps/sample/createandsavemap/MainActivity.kt
+++ b/create-and-save-map/src/main/java/com/esri/arcgismaps/sample/createandsavemap/MainActivity.kt
@@ -23,17 +23,27 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.arcgismaps.ArcGISEnvironment
 
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.createandsavemap.screens.MainScreen
 import com.arcgismaps.toolkit.authentication.DialogAuthenticator
+import com.arcgismaps.toolkit.authentication.signOut
 import com.esri.arcgismaps.sample.createandsavemap.components.MapViewModel
+import kotlinx.coroutines.runBlocking
 
 class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // This sample uses an ArcGIS Online login to be able to save a map as an ArcGIS portal item
+        // No need for license strings or an API key
+        ArcGISEnvironment.apiKey = null
 
+        // Sign out of any portals which are already authenticated
+        runBlocking {
+            ArcGISEnvironment.authenticationManager.signOut()
+        }
         setContent {
             SampleAppTheme {
                 SampleApp()

--- a/create-and-save-map/src/main/java/com/esri/arcgismaps/sample/createandsavemap/MainActivity.kt
+++ b/create-and-save-map/src/main/java/com/esri/arcgismaps/sample/createandsavemap/MainActivity.kt
@@ -24,7 +24,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.arcgismaps.ArcGISEnvironment
-
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.createandsavemap.screens.MainScreen
 import com.arcgismaps.toolkit.authentication.DialogAuthenticator


### PR DESCRIPTION
## Description
<!--
PR to add a new Kotlin sample _"SAMPLE_NAME"_ in `SAMPLE_CATEGORY` category.
-->

Updates Create and Save Map to unset API key & invalidate any existing OAuth credentials, making it play nice with the sample viewer.

## Links and Data

Sample Epic: [#2922](https://devtopia.esri.com/runtime/kotlin/issues/2922)
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [x] link: [Yep](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/45/)

## What To Review
- Is it sensible to use `runBlocking` like this? I had wanted to use `lifetimeScope`, but that caused the authenticator to loop indefinitely when re-running the sample in the viewer. This may cause a small delay when re-running the sample in the viewer.
- Does the sample work properly in the viewer?
  - In particular, does it behave as expected before and after running "Authenticate with OAuth", which sets an API key and authenticates the user?

## How to Test
Run the sample in the sample viewer.

<!-- OPTIONAL
## To Discuss
-->

<!-- OPTIONAL
## Screenshots
-->
