### PR TITLE
[Patch] Revoke OAuth tokens at sample start

### DIFF
--- a/authenticate-with-oauth/src/main/java/com/esri/arcgismaps/sample/authenticatewithoauth/MainActivity.kt
+++ b/authenticate-with-oauth/src/main/java/com/esri/arcgismaps/sample/authenticatewithoauth/MainActivity.kt
@@ -22,6 +22,7 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.toolkit.authentication.DialogAuthenticator
@@ -29,15 +30,20 @@ import com.arcgismaps.toolkit.authentication.signOut
 import com.esri.arcgismaps.sample.authenticatewithoauth.components.MapViewModel
 import com.esri.arcgismaps.sample.authenticatewithoauth.screens.MainScreen
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        // Remove any API key already set
+        // The concurrent use of an API key and user authentication is not supported
+        ArcGISEnvironment.apiKey = null
+
         // Sign out of any portals which are already authenticated
-        runBlocking {
+        lifecycleScope.launch(Dispatchers.Main) {
             ArcGISEnvironment.authenticationManager.signOut()
         }
 

--- a/authenticate-with-oauth/src/main/java/com/esri/arcgismaps/sample/authenticatewithoauth/MainActivity.kt
+++ b/authenticate-with-oauth/src/main/java/com/esri/arcgismaps/sample/authenticatewithoauth/MainActivity.kt
@@ -23,15 +23,23 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.toolkit.authentication.DialogAuthenticator
+import com.arcgismaps.toolkit.authentication.signOut
 import com.esri.arcgismaps.sample.authenticatewithoauth.components.MapViewModel
 import com.esri.arcgismaps.sample.authenticatewithoauth.screens.MainScreen
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
+import kotlinx.coroutines.runBlocking
 
 class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        // Sign out of any portals which are already authenticated
+        runBlocking {
+            ArcGISEnvironment.authenticationManager.signOut()
+        }
 
         setContent {
             SampleAppTheme {

--- a/create-and-save-map/src/main/java/com/esri/arcgismaps/sample/createandsavemap/MainActivity.kt
+++ b/create-and-save-map/src/main/java/com/esri/arcgismaps/sample/createandsavemap/MainActivity.kt
@@ -22,6 +22,7 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
@@ -29,7 +30,8 @@ import com.esri.arcgismaps.sample.createandsavemap.screens.MainScreen
 import com.arcgismaps.toolkit.authentication.DialogAuthenticator
 import com.arcgismaps.toolkit.authentication.signOut
 import com.esri.arcgismaps.sample.createandsavemap.components.MapViewModel
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
 
@@ -40,18 +42,19 @@ class MainActivity : ComponentActivity() {
         ArcGISEnvironment.apiKey = null
 
         // Sign out of any portals which are already authenticated
-        runBlocking {
+        lifecycleScope.launch(Dispatchers.Main) {
             ArcGISEnvironment.authenticationManager.signOut()
-        }
-        setContent {
-            SampleAppTheme {
-                SampleApp()
+
+            setContent {
+                SampleAppTheme {
+                    CreateAndSaveMapApp()
+                }
             }
         }
     }
 
     @Composable
-    private fun SampleApp() {
+    private fun CreateAndSaveMapApp() {
         val mapViewModel: MapViewModel = viewModel()
         Surface(
             color = MaterialTheme.colorScheme.background
@@ -59,9 +62,9 @@ class MainActivity : ComponentActivity() {
             MainScreen(
                 sampleName = getString(R.string.app_name)
             )
-        }
 
-        // authenticator at bottom can draw over the top of the sample
-        DialogAuthenticator(authenticatorState = mapViewModel.authenticatorState)
+            // authenticator at bottom can draw over the top of the sample
+            DialogAuthenticator(authenticatorState = mapViewModel.authenticatorState)
+        }
     }
 }

--- a/create-and-save-map/src/main/java/com/esri/arcgismaps/sample/createandsavemap/screens/MainScreen.kt
+++ b/create-and-save-map/src/main/java/com/esri/arcgismaps/sample/createandsavemap/screens/MainScreen.kt
@@ -43,8 +43,10 @@ import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
@@ -87,9 +89,10 @@ fun MainScreen(sampleName: String) {
     val composableScope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
     val controlsBottomSheetState = rememberBottomSheetScaffoldState(
-        bottomSheetState = rememberStandardBottomSheetState(skipHiddenState = false).apply {
-            composableScope.launch { hide() }
-        }
+        bottomSheetState = rememberStandardBottomSheetState(
+            initialValue = SheetValue.Hidden,
+            skipHiddenState = false
+        )
     )
 
     Scaffold(
@@ -274,7 +277,7 @@ fun FolderDropdown(
         OutlinedTextField(
             modifier = Modifier
                 .fillMaxWidth()
-                .menuAnchor(),
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable),
             value = label,
             onValueChange = { newDescription -> label = newDescription },
             label = { Text(text = "Folder:") },
@@ -339,7 +342,7 @@ fun BasemapDropdown(
         OutlinedTextField(
             modifier = Modifier
                 .fillMaxWidth()
-                .menuAnchor(),
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable),
             value = basemapStyle,
             onValueChange = {},
             label = { Text(text = "Basemap Style:") },
@@ -390,7 +393,7 @@ fun LayersDropdown(
         OutlinedTextField(
             modifier = Modifier
                 .fillMaxWidth()
-                .menuAnchor(),
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable),
             value = "Select...",
             onValueChange = {},
             label = { Text(text = "Operational Layers:") },

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ ktxAndroidCore = "1.13.0"
 kotlinCompilerExt = "1.5.12"
 # Compose versions
 composeActivityVersion = "1.9.0"
-composeBOM = "2024.04.01"
+composeBOM = "2024.09.03"
 # Library versions
 appcompatVersion = "1.6.1"
 commonsIoVersion = "2.15.1"

--- a/show-portal-user-info/src/main/java/com/esri/arcgismaps/sample/showportaluserinfo/MainActivity.kt
+++ b/show-portal-user-info/src/main/java/com/esri/arcgismaps/sample/showportaluserinfo/MainActivity.kt
@@ -24,8 +24,10 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import com.arcgismaps.ApiKey
 import com.arcgismaps.ArcGISEnvironment
+import com.arcgismaps.toolkit.authentication.signOut
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.showportaluserinfo.screens.MainScreen
+import kotlinx.coroutines.runBlocking
 
 class MainActivity : ComponentActivity() {
 
@@ -34,6 +36,11 @@ class MainActivity : ComponentActivity() {
         // authentication with an API key or named user is
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.API_KEY)
+
+        // Sign out of any portals which are already authenticated
+        runBlocking {
+            ArcGISEnvironment.authenticationManager.signOut()
+        }
 
         setContent {
             SampleAppTheme {

--- a/show-portal-user-info/src/main/java/com/esri/arcgismaps/sample/showportaluserinfo/MainActivity.kt
+++ b/show-portal-user-info/src/main/java/com/esri/arcgismaps/sample/showportaluserinfo/MainActivity.kt
@@ -22,23 +22,21 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
+import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.toolkit.authentication.signOut
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.showportaluserinfo.screens.MainScreen
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.API_KEY)
 
         // Sign out of any portals which are already authenticated
-        runBlocking {
+        lifecycleScope.launch(Dispatchers.Main) {
             ArcGISEnvironment.authenticationManager.signOut()
         }
 


### PR DESCRIPTION
## Description
Change "Show portal user info" and "Authenticate with OAuth" to remove any cached authentication from `ArcGISEnvironment`. This makes them behave properly in the sample viewer even after a user has authenticated in another sample 

## Links and Data
Sample Epic: [#4755](https://devtopia.esri.com/runtime/kotlin/issues/4755)
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [x] link: [Yes](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/47/)
## What To Review
-  Do the samples now behave as expected in the sample viewer?
- Is `runBlocking` the best way to implement this?

## How to Test
Run the samples in the sample viewer. Do they present an authentication challenge after completing one in another sample?

<!-- OPTIONAL
## To Discuss
-->

<!-- OPTIONAL
## Screenshots
-->
