### PR TITLE
Signing instructions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,17 +48,11 @@ android {
             }
             isMinifyEnabled = false
             proguardFiles(getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro")
+            // If signing.properties file not found, gradle will build an unsigned APK.
+            // For release builds, provide the required "signingPropsFilePath" for a signed APK, using:
+            // ./gradlew assembleRelease -PsigningPropsFilePath=absolute-file-path/signing.properties
             if (signingPropsFile.exists())
                 signingConfig = signingConfigs.getByName("esriSignature")
-            else {
-                Log.e(
-                    tag = "GradleSigningException",
-                    message = "signing.properties file not found: ${signingPropsFile.absolutePath}, this will build an unsigned APK.\n" +
-                            "Please provide the required \"signingPropsFilePath\" for a signed APK, using:\n" +
-                            "./gradlew assembleRelease -PsigningPropsFilePath=absolute-file-path/signing.properties"
-                )
-            }
-
         }
     }
 


### PR DESCRIPTION
## Description
PR to add singing instructions as a comment for clarity, rather than throwing an exception on each debug/release build. 

## Links and Data 
Issue: [#4597](https://devtopia.esri.com/runtime/kotlin/issues/4597)

