### PR TITLE
Simple fix to not re-running load

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:name=".SampleViewerApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/MainActivity.kt
+++ b/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/MainActivity.kt
@@ -23,15 +23,10 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.platform.LocalContext
-import androidx.lifecycle.lifecycleScope
 import androidx.navigation.compose.rememberNavController
-import com.esri.arcgismaps.kotlin.sampleviewer.model.DefaultSampleInfoRepository
 import com.esri.arcgismaps.kotlin.sampleviewer.navigation.LocalNavController
 import com.esri.arcgismaps.kotlin.sampleviewer.navigation.NavGraph
 import com.esri.arcgismaps.kotlin.sampleviewer.ui.theme.SampleAppTheme
-import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -39,12 +34,6 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             setContent {
-                val context = LocalContext.current
-                LaunchedEffect(Unit) {
-                    lifecycleScope.launch {
-                        DefaultSampleInfoRepository.load(context)
-                    }
-                }
 
                 SampleAppTheme {
                     Surface(color = MaterialTheme.colorScheme.background) {

--- a/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/SampleViewerApplication.kt
+++ b/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/SampleViewerApplication.kt
@@ -1,0 +1,16 @@
+package com.esri.arcgismaps.kotlin.sampleviewer
+
+import android.app.Application
+import com.esri.arcgismaps.kotlin.sampleviewer.model.DefaultSampleInfoRepository
+import kotlinx.coroutines.runBlocking
+
+class SampleViewerApplication: Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        runBlocking {
+            // Load the repository once at app launch
+            DefaultSampleInfoRepository.load(applicationContext)
+        }
+    }
+}

--- a/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/SampleViewerApplication.kt
+++ b/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/SampleViewerApplication.kt
@@ -2,14 +2,15 @@ package com.esri.arcgismaps.kotlin.sampleviewer
 
 import android.app.Application
 import com.esri.arcgismaps.kotlin.sampleviewer.model.DefaultSampleInfoRepository
-import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 class SampleViewerApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
-        MainScope().launch {
+        CoroutineScope(Dispatchers.IO).launch {
             // Load the repository once at app launch
             DefaultSampleInfoRepository.load(applicationContext)
         }

--- a/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/SampleViewerApplication.kt
+++ b/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/SampleViewerApplication.kt
@@ -2,13 +2,14 @@ package com.esri.arcgismaps.kotlin.sampleviewer
 
 import android.app.Application
 import com.esri.arcgismaps.kotlin.sampleviewer.model.DefaultSampleInfoRepository
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
 
 class SampleViewerApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
-        runBlocking {
+        MainScope().launch {
             // Load the repository once at app launch
             DefaultSampleInfoRepository.load(applicationContext)
         }

--- a/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/SampleViewerApplication.kt
+++ b/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/SampleViewerApplication.kt
@@ -4,7 +4,7 @@ import android.app.Application
 import com.esri.arcgismaps.kotlin.sampleviewer.model.DefaultSampleInfoRepository
 import kotlinx.coroutines.runBlocking
 
-class SampleViewerApplication: Application() {
+class SampleViewerApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()

--- a/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/model/DefaultSampleInfoRepository.kt
+++ b/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/model/DefaultSampleInfoRepository.kt
@@ -37,6 +37,8 @@ object DefaultSampleInfoRepository : SampleInfoRepository {
 
     private val isInitialized = AtomicBoolean(false)
 
+    private val json = Json { ignoreUnknownKeys = true }
+
     private val sampleList = mutableListOf<Sample>()
 
     /**
@@ -46,7 +48,7 @@ object DefaultSampleInfoRepository : SampleInfoRepository {
     suspend fun load(context: Context) {
         if (isInitialized.compareAndSet(false, true)) {
             // Iterate through the metadata folder for all metadata files
-            val json = Json { ignoreUnknownKeys = true }
+
             context.assets.list("samples")?.forEach { samplePath ->
                 // Get this metadata files as a string
                 context.assets.open("samples/$samplePath/README.metadata.json").use { inputStream ->

--- a/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/model/DefaultSampleInfoRepository.kt
+++ b/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/model/DefaultSampleInfoRepository.kt
@@ -44,7 +44,7 @@ object DefaultSampleInfoRepository : SampleInfoRepository {
      * of [Sample] objects.
      */
     suspend fun load(context: Context) {
-        if (isInitialized.compareAndSet(false,true)) {
+        if (isInitialized.compareAndSet(false, true)) {
             // Iterate through the metadata folder for all metadata files
             val json = Json { ignoreUnknownKeys = true }
             context.assets.list("samples")?.forEach { samplePath ->

--- a/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/model/DefaultSampleInfoRepository.kt
+++ b/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/model/DefaultSampleInfoRepository.kt
@@ -24,10 +24,9 @@ import com.esri.arcgismaps.kotlin.sampleviewer.model.Sample.Companion.loadScreen
 import com.esri.arcgismaps.kotlin.sampleviewer.model.room.AppDatabase
 import com.esri.arcgismaps.kotlin.sampleviewer.model.room.Converters
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * The single source of truth for app wide data. It reads the sample metadata to create as list of
@@ -36,67 +35,62 @@ import kotlinx.serialization.json.Json
  */
 object DefaultSampleInfoRepository : SampleInfoRepository {
 
-    private var isInitialized = false
+    private val isInitialized = AtomicBoolean(false)
 
     private val sampleList = mutableListOf<Sample>()
-    private val sampleListMutex = Mutex()
-
-    private suspend fun updateSampleList(block: MutableList<Sample>.() -> Unit) {
-        sampleListMutex.withLock { sampleList.block() }
-    }
 
     /**
      * Load the sample metadata from the metadata folder in the assets directory and updates sampleList
      * of [Sample] objects.
      */
     suspend fun load(context: Context) {
-        if (isInitialized) return
-        // Iterate through the metadata folder for all metadata files
-        val json = Json { ignoreUnknownKeys = true }
-        context.assets.list("samples")?.forEach { samplePath ->
-            // Get this metadata files as a string
-            context.assets.open("samples/$samplePath/README.metadata.json").use { inputStream ->
-                val metadataJsonString = inputStream.bufferedReader().use { it.readText() }
-                try {
-                    val metadata = json.decodeFromString<SampleMetadata>(metadataJsonString)
+        if (isInitialized.compareAndSet(false,true)) {
+            // Iterate through the metadata folder for all metadata files
+            val json = Json { ignoreUnknownKeys = true }
+            context.assets.list("samples")?.forEach { samplePath ->
+                // Get this metadata files as a string
+                context.assets.open("samples/$samplePath/README.metadata.json").use { inputStream ->
+                    val metadataJsonString = inputStream.bufferedReader().use { it.readText() }
+                    try {
+                        val metadata = json.decodeFromString<SampleMetadata>(metadataJsonString)
 
-                    // Create and add a new sample metadata data class object to the list
-                    val sample = Sample(
-                        name = metadata.title,
-                        codeFiles = Sample.loadCodeFiles(
-                            context = context,
-                            sampleName = metadata.title
-                        ),
-                        url = "https://developers.arcgis.com/kotlin/sample-code/" +
-                                metadata.title.replace(" ", "-").lowercase(),
-                        readMe = loadReadMe(
-                            context = context,
-                            sampleName = samplePath
-                        ),
-                        screenshotURL = loadScreenshot(
-                            sampleName = metadata.title,
-                            imageArray = metadata.imagePaths
-                        ),
-                        mainActivity = loadActivityPath(
-                            codePaths = metadata.codePaths
-                        ),
-                        metadata = metadata,
-                    )
-                    // Add the new sample to the list
-                    updateSampleList { add(sample) }
-                } catch (e: Exception) {
-                    Log.e(
-                        DefaultSampleInfoRepository::class.simpleName,
-                        "Exception at $samplePath: " + e.printStackTrace()
-                    )
+                        // Create and add a new sample metadata data class object to the list
+                        val sample = Sample(
+                            name = metadata.title,
+                            codeFiles = Sample.loadCodeFiles(
+                                context = context,
+                                sampleName = metadata.title
+                            ),
+                            url = "https://developers.arcgis.com/kotlin/sample-code/" +
+                                    metadata.title.replace(" ", "-").lowercase(),
+                            readMe = loadReadMe(
+                                context = context,
+                                sampleName = samplePath
+                            ),
+                            screenshotURL = loadScreenshot(
+                                sampleName = metadata.title,
+                                imageArray = metadata.imagePaths
+                            ),
+                            mainActivity = loadActivityPath(
+                                codePaths = metadata.codePaths
+                            ),
+                            metadata = metadata,
+                        )
+                        // Add the new sample to the list
+                        sampleList.add(sample)
+                    } catch (e: Exception) {
+                        Log.e(
+                            DefaultSampleInfoRepository::class.simpleName,
+                            "Exception at $samplePath: " + e.printStackTrace()
+                        )
+                    }
                 }
             }
+            withContext(Dispatchers.IO) {
+                // Populates the Room SQL database
+                populateDatabase(context)
+            }
         }
-        withContext(Dispatchers.IO) {
-            // Populates the Room SQL database
-            populateDatabase(context)
-        }
-        isInitialized = true
     }
 
     /**

--- a/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/model/DefaultSampleInfoRepository.kt
+++ b/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/model/DefaultSampleInfoRepository.kt
@@ -36,6 +36,8 @@ import kotlinx.serialization.json.Json
  */
 object DefaultSampleInfoRepository : SampleInfoRepository {
 
+    private var isInitialized = false
+
     private val sampleList = mutableListOf<Sample>()
     private val sampleListMutex = Mutex()
 
@@ -48,6 +50,7 @@ object DefaultSampleInfoRepository : SampleInfoRepository {
      * of [Sample] objects.
      */
     suspend fun load(context: Context) {
+        if (isInitialized) return
         // Iterate through the metadata folder for all metadata files
         val json = Json { ignoreUnknownKeys = true }
         context.assets.list("samples")?.forEach { samplePath ->
@@ -93,6 +96,7 @@ object DefaultSampleInfoRepository : SampleInfoRepository {
             // Populates the Room SQL database
             populateDatabase(context)
         }
+        isInitialized = true
     }
 
     /**


### PR DESCRIPTION
Explored dependency injection, which would require importing dagger/hilt and is probably beyond min ship.

How's this for a simple check to prevent repeat calls to load logic?