### PR TITLE
Update `Snap geometry edits` readme to include default haptics information

### DIFF
--- a/snap-geometry-edits/README.md
+++ b/snap-geometry-edits/README.md
@@ -65,6 +65,8 @@ Snapping can be used during interactive edits that move existing vertices using 
 
 Geometry guides are enabled by default when snapping is enabled. These allow for snapping to a point coinciding with, parallel to, perpendicular to, or extending an existing geometry.
 
+On supported platforms haptic feedback on `SnapState.snappedToFeature` and `SnapState.snappedToGeometryGuide` is enabled by default when snapping is enabled. Custom haptic feedback can be configured by setting `SnapSettings.isHapticFeedbackEnabled` to false and listening to `GeometryEditor.snapChanged` events to provide specific feedback depending on the `SnapState`.
+
 This sample uses the GeoViewCompose Toolkit module to be able to implement a Composable MapView.
 
 ## Tags


### PR DESCRIPTION
## Description

PR to update the Kotlin sample _"Snap geometry edits"_ in `Edit and Manage Data` category.

Included information on the default haptics experience, how to disable haptics and implement custom haptics based on `SnapState`.