### PR TITLE
Remove API key/OAuth workaround from Create & Save Map

### DIFF
--- a/create-and-save-map/src/main/java/com/esri/arcgismaps/sample/createandsavemap/MainActivity.kt
+++ b/create-and-save-map/src/main/java/com/esri/arcgismaps/sample/createandsavemap/MainActivity.kt
@@ -23,26 +23,16 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.createandsavemap.screens.MainScreen
 import com.arcgismaps.toolkit.authentication.DialogAuthenticator
-import com.arcgismaps.toolkit.authentication.signOut
 import com.esri.arcgismaps.sample.createandsavemap.components.MapViewModel
-import kotlinx.coroutines.runBlocking
 
 class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // This sample uses an ArcGIS Online login to be able to save a map as an ArcGIS portal item
-        // No need for license strings or an API key
-        ArcGISEnvironment.apiKey = null
 
-        // Sign out of any portals which are already authenticated
-        runBlocking {
-            ArcGISEnvironment.authenticationManager.signOut()
-        }
         setContent {
             SampleAppTheme {
                 SampleApp()


### PR DESCRIPTION
## Description
Removes the API key/OAuth revocation fix from Create & Save Map.
This should be done once https://github.com/Esri/arcgis-maps-sdk-kotlin-samples/pull/244 is merged.
## Links and Data

Sample Epic: `runtime/kotlin/issues/ISSUE_NUMBER`
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/49/

## What To Review / How to Test
- Run the sample on the (new) sample viewer once key/OAuth revocation is handled there.
- Ensure that the authenticator is displayed even when the sample is run repeatedly, or after other samples.

<!-- OPTIONAL
## To Discuss
-->

<!-- OPTIONAL
## Screenshots
-->
