### PR TITLE
Fix Analyze-network-with-subnetwork-trace sample

### DIFF
--- a/samples/analyze-network-with-subnetwork-trace/src/main/java/com/esri/arcgismaps/sample/analyzenetworkwithsubnetworktrace/MainActivity.kt
+++ b/samples/analyze-network-with-subnetwork-trace/src/main/java/com/esri/arcgismaps/sample/analyzenetworkwithsubnetworktrace/MainActivity.kt
@@ -455,12 +455,15 @@ class MainActivity : AppCompatActivity() {
         dataType: UtilityNetworkAttributeDataType,
     ): Any {
         return try {
-            when (dataType::class.objectInstance) {
-                UtilityNetworkAttributeDataType.Boolean -> otherValue.toString().toBoolean()
-                UtilityNetworkAttributeDataType.Double -> otherValue.toString().toDouble()
-                UtilityNetworkAttributeDataType.Float -> otherValue.toString().toFloat()
-                UtilityNetworkAttributeDataType.Integer -> otherValue.toString().toInt()
-                else -> {}
+            if (dataType::class.isInstance(UtilityNetworkAttributeDataType.Boolean)) {
+                otherValue.toString().toBoolean()
+            } else if (dataType::class.isInstance(UtilityNetworkAttributeDataType.Double)) {
+                otherValue.toString().toDouble()
+            } else if (dataType::class.isInstance(UtilityNetworkAttributeDataType.Float)) {
+                otherValue.toString().toFloat()
+            } else if (dataType::class.isInstance(UtilityNetworkAttributeDataType.Integer)) {
+                otherValue.toString().toInt()
+            } else {
             }
         } catch (e: Exception) {
             return ("Error converting value to a datatype")


### PR DESCRIPTION
## Description
PR to fix crash on Analyze-network-with-subnetwork-trace sample when adding a value transition. My guess is this is due to changes in  Kotlin `objectInstance`. 

## What To Review
- Test if the sample works as expected. 