### PR TITLE
Trev8939/handle async samples list

### DIFF
--- a/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/model/DefaultSampleInfoRepository.kt
+++ b/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/model/DefaultSampleInfoRepository.kt
@@ -44,8 +44,7 @@ object DefaultSampleInfoRepository : SampleInfoRepository {
     private val json = Json { ignoreUnknownKeys = true }
 
     private val _sampleData = MutableStateFlow<List<Sample>>(emptyList())
-
-    val sampleData = _sampleData.asStateFlow() // Read-only flow for observing data
+    private val sampleData = _sampleData.asStateFlow()
 
     /**
      * Load the sample metadata from the metadata folder in the assets directory and updates sampleList
@@ -107,7 +106,7 @@ object DefaultSampleInfoRepository : SampleInfoRepository {
      * Populates the Room SQL database with all samples and sample info
      */
     private suspend fun populateDatabase(context: Context) {
-        val sampleEntities = _sampleData.value.map { Converters().convertToEntity(sample = it) }
+        val sampleEntities = sampleData.value.map { Converters().convertToEntity(sample = it) }
         AppDatabase.getDatabase(context).clearAllTables()
         AppDatabase.getDatabase(context).sampleDao().insertAll(samples = sampleEntities)
     }
@@ -116,13 +115,13 @@ object DefaultSampleInfoRepository : SampleInfoRepository {
      * Get a sample by its name. Either the formal name or title.
      */
     override fun getSampleByName(sampleName: String): Flow<Sample> {
-        return _sampleData.map { it.first { sample -> sample.metadata.formalName == sampleName || sample.metadata.title == sampleName } }
+        return sampleData.map { it.first { sample -> sample.metadata.formalName == sampleName || sample.metadata.title == sampleName } }
     }
 
     /**
      * Get a list of samples for the given [SampleCategory].
      */
     override fun getSamplesInCategory(sampleCategory: SampleCategory): Flow<List<Sample>> {
-        return _sampleData.map { it.filter { sample -> sample.metadata.sampleCategory == sampleCategory } }
+        return sampleData.map { it.filter { sample -> sample.metadata.sampleCategory == sampleCategory } }
     }
 }

--- a/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/model/DefaultSampleInfoRepository.kt
+++ b/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/model/DefaultSampleInfoRepository.kt
@@ -24,6 +24,10 @@ import com.esri.arcgismaps.kotlin.sampleviewer.model.Sample.Companion.loadScreen
 import com.esri.arcgismaps.kotlin.sampleviewer.model.room.AppDatabase
 import com.esri.arcgismaps.kotlin.sampleviewer.model.room.Converters
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import java.util.concurrent.atomic.AtomicBoolean
@@ -39,7 +43,9 @@ object DefaultSampleInfoRepository : SampleInfoRepository {
 
     private val json = Json { ignoreUnknownKeys = true }
 
-    private val sampleList = mutableListOf<Sample>()
+    private val _sampleData = MutableStateFlow<List<Sample>>(emptyList())
+
+    val sampleData = _sampleData.asStateFlow() // Read-only flow for observing data
 
     /**
      * Load the sample metadata from the metadata folder in the assets directory and updates sampleList
@@ -47,8 +53,9 @@ object DefaultSampleInfoRepository : SampleInfoRepository {
      */
     suspend fun load(context: Context) {
         if (isInitialized.compareAndSet(false, true)) {
+            // List that will be populated with samples
+            val sampleList = mutableListOf<Sample>()
             // Iterate through the metadata folder for all metadata files
-
             context.assets.list("samples")?.forEach { samplePath ->
                 // Get this metadata files as a string
                 context.assets.open("samples/$samplePath/README.metadata.json").use { inputStream ->
@@ -88,6 +95,7 @@ object DefaultSampleInfoRepository : SampleInfoRepository {
                     }
                 }
             }
+            _sampleData.value = sampleList
             withContext(Dispatchers.IO) {
                 // Populates the Room SQL database
                 populateDatabase(context)
@@ -99,7 +107,7 @@ object DefaultSampleInfoRepository : SampleInfoRepository {
      * Populates the Room SQL database with all samples and sample info
      */
     private suspend fun populateDatabase(context: Context) {
-        val sampleEntities = sampleList.map { Converters().convertToEntity(sample = it) }
+        val sampleEntities = _sampleData.value.map { Converters().convertToEntity(sample = it) }
         AppDatabase.getDatabase(context).clearAllTables()
         AppDatabase.getDatabase(context).sampleDao().insertAll(samples = sampleEntities)
     }
@@ -107,14 +115,14 @@ object DefaultSampleInfoRepository : SampleInfoRepository {
     /**
      * Get a sample by its name. Either the formal name or title.
      */
-    override fun getSampleByName(sampleName: String): Sample {
-        return sampleList.first { it.metadata.formalName == sampleName || it.metadata.title == sampleName }
+    override fun getSampleByName(sampleName: String): Flow<Sample> {
+        return _sampleData.map { it.first { sample -> sample.metadata.formalName == sampleName || sample.metadata.title == sampleName } }
     }
 
     /**
      * Get a list of samples for the given [SampleCategory].
      */
-    override fun getSamplesInCategory(sampleCategory: SampleCategory): List<Sample> {
-        return sampleList.filter { it.metadata.sampleCategory == sampleCategory }
+    override fun getSamplesInCategory(sampleCategory: SampleCategory): Flow<List<Sample>> {
+        return _sampleData.map { it.filter { sample -> sample.metadata.sampleCategory == sampleCategory } }
     }
 }

--- a/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/model/SampleInfoRepository.kt
+++ b/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/model/SampleInfoRepository.kt
@@ -16,12 +16,14 @@
 
 package com.esri.arcgismaps.kotlin.sampleviewer.model
 
+import kotlinx.coroutines.flow.Flow
+
 /**
  * A repository interface to fetch sample information.
  */
 interface SampleInfoRepository {
 
-    fun getSamplesInCategory(sampleCategory: SampleCategory): List<Sample>
+    fun getSamplesInCategory(sampleCategory: SampleCategory): Flow<List<Sample>>
 
-    fun getSampleByName(sampleName: String): Sample
+    fun getSampleByName(sampleName: String): Flow<Sample>
 }

--- a/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/navigation/NavGraph.kt
+++ b/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/navigation/NavGraph.kt
@@ -20,6 +20,8 @@ import android.content.Context
 import android.util.Log
 import android.widget.Toast
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
@@ -92,12 +94,15 @@ internal fun NavGraph() {
             val sampleNameNavEntry = backStackEntry.arguments?.getString("sampleName")
 
             if (optionPositionNavEntry != null && !sampleNameNavEntry.isNullOrEmpty()) {
-                val sampleNavEntry = DefaultSampleInfoRepository.getSampleByName(sampleNameNavEntry)
-                SampleInfoScreen(
-                    sample = sampleNavEntry,
-                    optionPosition = optionPositionNavEntry,
-                    onBackPressed = { navController.pop() }
-                )
+                val sampleNavEntry by DefaultSampleInfoRepository.getSampleByName(sampleNameNavEntry)
+                    .collectAsState(null)
+                sampleNavEntry?.let {
+                    SampleInfoScreen(
+                        sample = it,
+                        optionPosition = optionPositionNavEntry,
+                        onBackPressed = { navController.pop() }
+                    )
+                }
             } else if (optionPositionNavEntry == null) {
                 navController.displayError("optionPositionNavEntry is null", context)
             } else {

--- a/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/ui/screens/sampleList/SampleListScreen.kt
+++ b/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/ui/screens/sampleList/SampleListScreen.kt
@@ -71,7 +71,8 @@ fun SampleListScreen(
     val favoriteSamplesFlow = remember { viewModel.getFavorites() }
     val favoriteSamples by favoriteSamplesFlow.collectAsState(initial = emptyList())
     val category = SampleCategory.toEnum(categoryNavEntry)
-    val samplesList = DefaultSampleInfoRepository.getSamplesInCategory(category)
+    val samplesList by DefaultSampleInfoRepository.getSamplesInCategory(category)
+        .collectAsState(initial = emptyList())
 
     Scaffold(
         topBar = { SampleViewerTopAppBar(title = category.text, onBackPressed) },

--- a/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/ui/screens/search/SearchSuggestionsScreen.kt
+++ b/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/ui/screens/search/SearchSuggestionsScreen.kt
@@ -167,13 +167,14 @@ fun SearchSuggestionsList(
                     key = { suggestion -> suggestion }
                 ) { suggestion ->
                     if (suggestion.second) { // Sample Suggestion
-                        val sample = DefaultSampleInfoRepository.getSampleByName(suggestion.first)
+                        val sample by DefaultSampleInfoRepository.getSampleByName(suggestion.first)
+                            .collectAsState(initial = null)
                         Row(
                             modifier = Modifier
                                 .animateItem()
-                                .clickable { onSampleSelected(sample) }
+                                .clickable { sample?.let { onSampleSelected(it) } }
                         ) {
-                            SampleListItem(sample.name)
+                            sample?.let { SampleListItem(it.name) }
                         }
                     } else { // RelevantAPI Suggestion
                         val relevantApi = suggestion.first

--- a/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/viewmodels/SampleSearchViewModel.kt
+++ b/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/viewmodels/SampleSearchViewModel.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
@@ -96,7 +97,7 @@ class SampleSearchViewModel(private val application: Application) : AndroidViewM
                     // Add the score to the sample.
                     val sample = DefaultSampleInfoRepository.getSampleByName(
                         sampleName = cursor.getString(0)
-                    ).apply {
+                    ).first().apply {
                         score = totalScore
                     }
                     results.add(sample)


### PR DESCRIPTION
## Description

Fixes race condition on early access to sample data in the DefaultSampleInfoRepository

## Links and Data
<!--
Sample Epic: `runtime/kotlin/issues/ISSUE_NUMBER`
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [ ] link:
-->
## What To Review
<!--
-  Review the code to make sure it is easy to follow like other samples on Android
- `README.md` and `README.metadata.json` files
-->

## How to Test

MUST BE RUN WITH INVALID API KEY

1) Select Visualization category
2) Run Play KML Tour and download data or continue
3) Wait 10 seconds on blank scene view
4) Click Play tour
5) If app recovers from crash, Visualization category repopulates with relevant samples after a brief pause