### PR TITLE
Fix GeodatabaseSyncTask link so it points to Kotlin API Ref instead of Java API Ref

### DIFF
--- a/samples/display-dimensions/README.md
+++ b/samples/display-dimensions/README.md
@@ -31,7 +31,7 @@ This sample shows a subset of the Edinburgh, Scotland network of pylons, substat
 
 ## Additional information
 
-Dimension layers can be taken offline from a feature service hosted on ArcGIS Enterprise 10.9 or later, using the [GeodatabaseSyncTask](https://developers.arcgis.com/java/api-reference/reference/com/esri/arcgisruntime/tasks/geodatabase/GeodatabaseSyncTask.html). Dimension layers are also supported in mobile map packages or mobile geodatabases created in ArcGIS Pro 2.9 or later.
+Dimension layers can be taken offline from a feature service hosted on ArcGIS Enterprise 10.9 or later, using the [GeodatabaseSyncTask](https://developers.arcgis.com/kotlin/api-reference/arcgis-maps-kotlin/com.arcgismaps.tasks.geodatabase/-geodatabase-sync-task/index.html). Dimension layers are also supported in mobile map packages or mobile geodatabases created in ArcGIS Pro 2.9 or later.
 
 ## Tags
 


### PR DESCRIPTION
## Description
<!--
PR to add a new Kotlin sample _"SAMPLE_NAME"_ in `SAMPLE_CATEGORY` category.
-->
The `GeodatabaseSyncTask` link in the README for **Display dimensions** sample points to the Maps SDK for Java API Ref, instead of the Maps SDK for Kotlin API Ref. And even with that wrong target, the link is broken.
- https://next.sites.afd.arcgis.com/kotlin/sample-code/display-dimensions/#additional-information

## What To Review
<!--
-  Review the code to make sure it is easy to follow like other samples on Android
- `README.md` and `README.metadata.json` files
-->
Verify that the `GeodatabaseSyncTask` link goes to the Kotlin API Ref.

## How to Test
<!--
Run the sample on the sample viewer or the repo.
-->
Click the link. See where it goes. It should go to https://developers.arcgis.com/kotlin/api-reference/arcgis-maps-kotlin/com.arcgismaps.tasks.geodatabase/-geodatabase-sync-task/index.html
