### PR TITLE
add-web-tiled-layer: rename Screen & ViewModel classes

### DIFF
--- a/samples/add-web-tiled-layer/src/main/java/com/esri/arcgismaps/sample/addwebtiledlayer/components/AddWebTiledLayerViewModel.kt
+++ b/samples/add-web-tiled-layer/src/main/java/com/esri/arcgismaps/sample/addwebtiledlayer/components/AddWebTiledLayerViewModel.kt
@@ -27,7 +27,7 @@ import com.esri.arcgismaps.sample.addwebtiledlayer.R
 import com.esri.arcgismaps.sample.sampleslib.components.MessageDialogViewModel
 import kotlinx.coroutines.launch
 
-class MapViewModel(application: Application) : AndroidViewModel(application) {
+class AddWebTiledLayerViewModel(application: Application) : AndroidViewModel(application) {
     // build the web tiled layer from ArcGIS Living Atlas of the World tile service url
     private val webTiledLayer = WebTiledLayer.create(
         urlTemplate = "https://server.arcgisonline.com/arcgis/rest/services/Ocean/World_Ocean_Base/MapServer/tile/{level}/{row}/{col}.jpg"

--- a/samples/add-web-tiled-layer/src/main/java/com/esri/arcgismaps/sample/addwebtiledlayer/screens/AddWebTiledLayerScreen.kt
+++ b/samples/add-web-tiled-layer/src/main/java/com/esri/arcgismaps/sample/addwebtiledlayer/screens/AddWebTiledLayerScreen.kt
@@ -24,7 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.arcgismaps.toolkit.geoviewcompose.MapView
-import com.esri.arcgismaps.sample.addwebtiledlayer.components.MapViewModel
+import com.esri.arcgismaps.sample.addwebtiledlayer.components.AddWebTiledLayerViewModel
 import com.esri.arcgismaps.sample.sampleslib.components.MessageDialog
 import com.esri.arcgismaps.sample.sampleslib.components.SampleTopAppBar
 
@@ -33,7 +33,7 @@ import com.esri.arcgismaps.sample.sampleslib.components.SampleTopAppBar
  */
 @Composable
 fun AddWebTiledLayerScreen(sampleName: String) {
-    val mapViewModel: MapViewModel = viewModel()
+    val mapViewModel: AddWebTiledLayerViewModel = viewModel()
     Scaffold(
         topBar = { SampleTopAppBar(title = sampleName) },
         content = {


### PR DESCRIPTION
## Description
<!--
PR to add a new Kotlin sample _"SAMPLE_NAME"_ in `SAMPLE_CATEGORY` category.
-->

This just renames the following classes in the add-web-tiled-layer sample, to make them consistent with what the `NewModuleScript` uses:
- `MapViewModel` to `AddWebTiledLayerViewModel`
- `MainScreen` to `AddWebTiledLayerScreen`

## Links and Data

- Issue: https://devtopia.esri.com/runtime/kotlin/issues/4968
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [ ] link:

## What To Review
<!--
-  Review the code to make sure it is easy to follow like other samples on Android
- `README.md` and `README.metadata.json` files
-->

## How to Test
<!--
Run the sample on the sample viewer or the repo.
-->

<!-- OPTIONAL
## To Discuss
-->

<!-- OPTIONAL
## Screenshots
-->
