### PR TITLE
Fix typo in reset button string

### DIFF
--- a/samples/clip-geometry/src/main/java/com/esri/arcgismaps/sample/clipgeometry/screens/ClipGeometryScreen.kt
+++ b/samples/clip-geometry/src/main/java/com/esri/arcgismaps/sample/clipgeometry/screens/ClipGeometryScreen.kt
@@ -72,7 +72,7 @@ fun ClipGeometryScreen(sampleName: String) {
                         }
                     ) {
                         Text(
-                            text = stringResource(R.string.rest_button_text)
+                            text = stringResource(R.string.reset_button_text)
                         )
                     }
                     Button(

--- a/samples/clip-geometry/src/main/res/values/strings.xml
+++ b/samples/clip-geometry/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
     <string name="clip_geometry_app_name">Clip geometry</string>
     <string name="clip_geometry_button_text">Clip geometry</string>
-    <string name="rest_button_text">Reset</string>
+    <string name="reset_button_text">Reset</string>
 </resources>


### PR DESCRIPTION
## Description
Fix simple typo in clip geometry sample's strings ("rest_button_text" -> "reset_button_text")
## How to Test
Run sample on sample viewer if necessary

<!-- OPTIONAL
## To Discuss
-->

<!-- OPTIONAL
## Screenshots
-->
