### PR TITLE
Add copyright header to DownloadActivity

### DIFF
--- a/samples/add-feature-layers/src/main/java/com/esri/arcgismaps/sample/addfeaturelayers/DownloadActivity.kt
+++ b/samples/add-feature-layers/src/main/java/com/esri/arcgismaps/sample/addfeaturelayers/DownloadActivity.kt
@@ -1,3 +1,19 @@
+/* Copyright 2022 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.esri.arcgismaps.sample.addfeaturelayers
 
 import android.content.Intent

--- a/samples/add-features-with-contingent-values/src/main/java/com/esri/arcgismaps/sample/addfeatureswithcontingentvalues/DownloadActivity.kt
+++ b/samples/add-features-with-contingent-values/src/main/java/com/esri/arcgismaps/sample/addfeatureswithcontingentvalues/DownloadActivity.kt
@@ -1,3 +1,19 @@
+/* Copyright 2024 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.esri.arcgismaps.sample.addfeatureswithcontingentvalues
 
 import android.content.Intent

--- a/samples/apply-dictionary-renderer-to-feature-layer/src/main/java/com/esri/arcgismaps/sample/applydictionaryrenderertofeaturelayer/DownloadActivity.kt
+++ b/samples/apply-dictionary-renderer-to-feature-layer/src/main/java/com/esri/arcgismaps/sample/applydictionaryrenderertofeaturelayer/DownloadActivity.kt
@@ -1,3 +1,19 @@
+/* Copyright 2023 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.esri.arcgismaps.sample.applydictionaryrenderertofeaturelayer
 
 import android.content.Intent

--- a/samples/display-device-location-with-nmea-data-sources/src/main/java/com/esri/arcgismaps/sample/displaydevicelocationwithnmeadatasources/DownloadActivity.kt
+++ b/samples/display-device-location-with-nmea-data-sources/src/main/java/com/esri/arcgismaps/sample/displaydevicelocationwithnmeadatasources/DownloadActivity.kt
@@ -1,3 +1,19 @@
+/* Copyright 2022 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.esri.arcgismaps.sample.displaydevicelocationwithnmeadatasources
 
 import android.content.Intent

--- a/samples/display-dimensions/src/main/java/com/esri/arcgismaps/sample/displaydimensions/DownloadActivity.kt
+++ b/samples/display-dimensions/src/main/java/com/esri/arcgismaps/sample/displaydimensions/DownloadActivity.kt
@@ -1,3 +1,19 @@
+/* Copyright 2023 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.esri.arcgismaps.sample.displaydimensions
 
 import android.content.Intent

--- a/samples/find-route-in-transport-network/src/main/java/com/esri/arcgismaps/sample/findrouteintransportnetwork/DownloadActivity.kt
+++ b/samples/find-route-in-transport-network/src/main/java/com/esri/arcgismaps/sample/findrouteintransportnetwork/DownloadActivity.kt
@@ -1,3 +1,19 @@
+/* Copyright 2023 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.esri.arcgismaps.sample.findrouteintransportnetwork
 
 import android.content.Intent

--- a/samples/geocode-offline/src/main/java/com/esri/arcgismaps/sample/geocodeoffline/DownloadActivity.kt
+++ b/samples/geocode-offline/src/main/java/com/esri/arcgismaps/sample/geocodeoffline/DownloadActivity.kt
@@ -1,3 +1,19 @@
+/* Copyright 2023 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.esri.arcgismaps.sample.geocodeoffline
 
 import android.content.Intent


### PR DESCRIPTION
## Description
Some copies of `DownloadActivity` were missing a copyright header. This PR adds them in with the correct date for each sample.

## Links and Data
Sample Epic: `runtime/kotlin/issues/ISSUE_NUMBER`
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [x] link: [here](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/72/)
## What To Review
<!--
-  Review the code to make sure it is easy to follow like other samples on Android
- `README.md` and `README.metadata.json` files
-->

## How to Test
<!--
Run the sample on the sample viewer or the repo.
-->

<!-- OPTIONAL
## To Discuss
-->

<!-- OPTIONAL
## Screenshots
-->
