### PR TITLE
Sample build JSON asset data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ build/
 Icon?
 ehthumbs.db
 Thumbs.db
+*.salive

--- a/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/SampleViewerLauncherActivity.kt
+++ b/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/SampleViewerLauncherActivity.kt
@@ -45,6 +45,7 @@ class SampleViewerLauncherActivity : ComponentActivity(), ExceptionListener {
 
         startActivity(Intent(this, MainActivity::class.java).apply {
             addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             putExtras(extras)
         })

--- a/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/model/DefaultSampleInfoRepository.kt
+++ b/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/model/DefaultSampleInfoRepository.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.kotlin.sampleviewer.model
 import android.content.Context
 import android.util.Log
 import com.esri.arcgismaps.kotlin.sampleviewer.model.Sample.Companion.loadActivityPath
+import com.esri.arcgismaps.kotlin.sampleviewer.model.Sample.Companion.loadCodeFiles
 import com.esri.arcgismaps.kotlin.sampleviewer.model.Sample.Companion.loadReadMe
 import com.esri.arcgismaps.kotlin.sampleviewer.model.Sample.Companion.loadScreenshot
 import com.esri.arcgismaps.kotlin.sampleviewer.model.room.AppDatabase
@@ -33,7 +34,7 @@ import kotlinx.serialization.json.Json
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
- * The single source of truth for app wide data. It reads the sample metadata to create as list of
+ * The single source of truth for app wide data. It reads the sample metadata to create a list of
  * [Sample] objects and populates the database used for search.
  * It also provides functions to get samples by category, name, or all samples.
  */
@@ -47,51 +48,51 @@ object DefaultSampleInfoRepository : SampleInfoRepository {
     private val sampleData = _sampleData.asStateFlow()
 
     /**
-     * Load the sample metadata from the metadata folder in the assets directory and updates sampleList
+     * Load the sample metadata from 'samples.json' in the assets directory and updates sampleList
      * of [Sample] objects.
      */
     suspend fun load(context: Context) {
         if (isInitialized.compareAndSet(false, true)) {
             // List that will be populated with samples
             val sampleList = mutableListOf<Sample>()
-            // Iterate through the metadata folder for all metadata files
-            context.assets.list("samples")?.forEach { samplePath ->
-                // Get this metadata files as a string
-                context.assets.open("samples/$samplePath/README.metadata.json").use { inputStream ->
-                    val metadataJsonString = inputStream.bufferedReader().use { it.readText() }
-                    try {
-                        val metadata = json.decodeFromString<SampleMetadata>(metadataJsonString)
 
-                        // Create and add a new sample metadata data class object to the list
-                        val sample = Sample(
-                            name = metadata.title,
-                            codeFiles = Sample.loadCodeFiles(
-                                context = context,
-                                sampleName = metadata.title
-                            ),
-                            url = "https://developers.arcgis.com/kotlin/sample-code/" +
-                                    metadata.title.replace(" ", "-").lowercase(),
-                            readMe = loadReadMe(
-                                context = context,
-                                sampleName = samplePath
-                            ),
-                            screenshotURL = loadScreenshot(
-                                sampleName = metadata.title,
-                                imageArray = metadata.imagePaths
-                            ),
-                            mainActivity = loadActivityPath(
-                                codePaths = metadata.codePaths
-                            ),
-                            metadata = metadata,
-                        )
-                        // Add the new sample to the list
-                        sampleList.add(sample)
-                    } catch (e: Exception) {
-                        Log.e(
-                            DefaultSampleInfoRepository::class.simpleName,
-                            "Exception at $samplePath: " + e.printStackTrace()
-                        )
-                    }
+            // Read the entire 'samples.json' from build/sampleAssets/samples/
+            val samplesJsonString = context.assets.open("samples/samples.json").use { stream ->
+                stream.bufferedReader().use { it.readText() }
+            }
+
+            // Parse it into a map of: sampleFolderName -> mapOf( filename -> fileContent )
+            val allSamplesData = json.decodeFromString<Map<String, Map<String, String>>>(samplesJsonString)
+
+            // Build each Sample using the metadata from "README.metadata.json"
+            allSamplesData.forEach { (sampleFolderName, fileMap) ->
+                val metadataJsonString = fileMap["README.metadata.json"] ?: return@forEach
+                try {
+                    val metadata = json.decodeFromString<SampleMetadata>(metadataJsonString)
+
+                    // Create and add a new sample metadata data class object to the list
+                    val sample = Sample(
+                        name = metadata.title,
+                        codeFiles = loadCodeFiles(fileMap),
+                        url = "https://developers.arcgis.com/kotlin/sample-code/" +
+                                metadata.title.replace(" ", "-").lowercase(),
+                        readMe = loadReadMe(fileMap),
+                        screenshotURL = loadScreenshot(
+                            sampleName = metadata.title,
+                            imageArray = metadata.imagePaths
+                        ),
+                        mainActivity = loadActivityPath(
+                            codePaths = metadata.codePaths
+                        ),
+                        metadata = metadata
+                    )
+                    // Add the new sample to the list
+                    sampleList.add(sample)
+                } catch (e: Exception) {
+                    Log.e(
+                        DefaultSampleInfoRepository::class.simpleName,
+                        "Exception at $sampleFolderName: ${e.stackTraceToString()}"
+                    )
                 }
             }
             _sampleData.value = sampleList

--- a/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/model/DefaultSampleInfoRepository.kt
+++ b/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/model/DefaultSampleInfoRepository.kt
@@ -66,7 +66,8 @@ object DefaultSampleInfoRepository : SampleInfoRepository {
 
             // Build each Sample using the metadata from "README.metadata.json"
             allSamplesData.forEach { (sampleFolderName, fileMap) ->
-                val metadataJsonString = fileMap["README.metadata.json"] ?: return@forEach
+                val metadataJsonString = fileMap["README.metadata.json"]
+                    ?: throw Exception("README.metadata.json not found in sample: $sampleFolderName")
                 try {
                     val metadata = json.decodeFromString<SampleMetadata>(metadataJsonString)
 

--- a/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/model/Sample.kt
+++ b/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/model/Sample.kt
@@ -78,7 +78,8 @@ data class Sample(
          * Returns the readme for a given sample [fileMap].
          */
         fun loadReadMe(fileMap: Map<String, String>): String {
-            val readMeString = fileMap["README.md"] ?: return ""
+            val readMeString = fileMap["README.md"]
+                ?: throw Exception("README.md not found in sample.")
             // Remove screenshot markdown text from the README
             return readMeString.lines().filterNot { it.contains("![") }.joinToString("\n")
         }

--- a/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/model/Sample.kt
+++ b/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/model/Sample.kt
@@ -62,41 +62,25 @@ data class Sample(
         )
 
         /**
-         * Returns a list of [CodeFile] objects for the given sample name.
+         * Returns a list of [CodeFile] objects for the given sample [fileMap].
          */
-        fun loadCodeFiles(context: Context, sampleName: String): List<CodeFile> {
-            // List of code files to be populated
+        fun loadCodeFiles(fileMap: Map<String, String>): List<CodeFile> {
             val codeFiles = mutableListOf<CodeFile>()
-            // Code file folders stored in assets directory as kebab case
-            val sampleNameKebabCase = sampleName.replace(" ", "-").lowercase()
-            val sampleAssetFiles = context.assets.list("samples/$sampleNameKebabCase/")
-            // Get the code files from sub-directories (components/, screens/)
-            sampleAssetFiles?.forEach { sampleAssetFile ->
-                if (sampleAssetFile.contains(".kt")) {
-                    val codeString = context.assets.open(
-                        /* fileName = */ "samples/$sampleNameKebabCase/$sampleAssetFile"
-                    ).bufferedReader().use { it.readText() }
-                    codeFiles.add(
-                        CodeFile(
-                            name = sampleAssetFile,
-                            code = codeString
-                        )
-                    )
+            fileMap.forEach { (fileName, fileContent) ->
+                if (fileName.endsWith(".kt", ignoreCase = true)) {
+                    codeFiles.add(CodeFile(name = fileName, code = fileContent))
                 }
             }
             return codeFiles
         }
 
         /**
-         * Returns the readme for a given sample name.
+         * Returns the readme for a given sample [fileMap].
          */
-        fun loadReadMe(context: Context, sampleName: String): String {
-            // Get this metadata files as a string
-            context.assets.open("samples/$sampleName/README.md").use { inputStream ->
-                val readMeString = inputStream.bufferedReader().use { it.readText() }
-                // Remove screenshot markdown text from the README
-                return readMeString.lines().filterNot { it.contains("![") }.joinToString("\n")
-            }
+        fun loadReadMe(fileMap: Map<String, String>): String {
+            val readMeString = fileMap["README.md"] ?: return ""
+            // Remove screenshot markdown text from the README
+            return readMeString.lines().filterNot { it.contains("![") }.joinToString("\n")
         }
 
         /**

--- a/gradle-plugins/build.gradle.kts
+++ b/gradle-plugins/build.gradle.kts
@@ -16,3 +16,7 @@ gradlePlugin {
         }
     }
 }
+
+dependencies {
+    implementation(libs.kotlinx.serialization.json)
+}

--- a/gradle-plugins/settings.gradle.kts
+++ b/gradle-plugins/settings.gradle.kts
@@ -1,1 +1,13 @@
 rootProject.name = "gradle-plugins"
+
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/gradle-plugins/src/main/kotlin/com/arcgismaps/CopySampleFilesTask.kt
+++ b/gradle-plugins/src/main/kotlin/com/arcgismaps/CopySampleFilesTask.kt
@@ -1,17 +1,23 @@
 package com.arcgismaps
 
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.Copy
 import org.gradle.kotlin.dsl.register
+import java.io.File
 
 /**
  * Copy md, kt, and json files to a directory (with the name of the associated sample)
  * into the app's build assets directory.
  */
 class CopySampleFilesTask : Plugin<Project> {
+
+    private val json = Json { prettyPrint = true }
+
     override fun apply(project: Project) {
         project.tasks.register<Copy>("copyCodeFiles") {
             description = """
@@ -42,6 +48,58 @@ class CopySampleFilesTask : Plugin<Project> {
 
             // Place in the assets codeFiles folder of the app.
             into(outputDir)
+
+            // After the copy finishes, run JSON generation + cleanup
+            doLast {
+                // Create a JSON file that maps each sample folder’s files to their contents
+                createJsonAssetFile(outputDir)
+
+                // Delete everything but the JSON file itself
+                outputDir.listFiles()?.forEach { file ->
+                    if (file.isDirectory || file.name != "samples.json") {
+                        file.deleteRecursively()
+                    }
+                }
+            }
         }
+    }
+
+    /**
+     * Creates the main list of all samples as "samples.json" file in [outputDir] with structure:
+     *
+     * {
+     *   "sampleA": {
+     *     "MainActivity.kt": "...content...",
+     *     "README.md": "...content...",
+     *     ...
+     *   },
+     *   "sampleB": {
+     *      ...
+     *   }
+     * }
+     */
+    private fun createJsonAssetFile(outputDir: File) {
+        // This map will hold the structure: sampleDirName -> { filename -> fileContent }
+        val samplesMap = mutableMapOf<String, MutableMap<String, String>>()
+
+        // List subdirectories in outputDir (i.e., each sample folder)
+        outputDir.listFiles()
+            ?.filter { it.isDirectory }
+            ?.forEach { sampleDir ->
+                val filesMap = mutableMapOf<String, String>()
+                sampleDir.listFiles()?.forEach { file ->
+                    if (file.isFile) {
+                        filesMap[file.name] = file.readText()
+                    }
+                }
+                samplesMap[sampleDir.name] = filesMap
+            }
+
+        // Serialize using Kotlin Serialization with pretty printing
+        val jsonString = json.encodeToString(samplesMap)
+
+        // Write the JSON to a file named "samples.json" in outputDir
+        val jsonFile = File(outputDir, "samples.json")
+        jsonFile.writeText(jsonString)
     }
 }


### PR DESCRIPTION
## Description
PR to address build files source code misleading android studio. The changes in this PR aims to not use local copied files, but instead maintain a JSON sample asset data with all (100) samples assets in a `sampleAssets/samples.json`:  

```json
{
   "sampleA": {
     "MainActivity.kt": "...content...",
     "README.md": "...content...",
     ...
   },
   "sampleB": {
      ...
   }
}
```


- Note: Run a build `clean` before running the changes in this branch. 

## Links and Data
Sample Epic: [#5467](https://devtopia.esri.com/runtime/kotlin/issues/5467)
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/89/
