### PR TITLE
Make AR module optional for the sample viewer

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 # ArcGIS Maps SDK for Kotlin version
-arcgisMapsKotlinVersion = "200.7.0-4549"
+arcgisMapsKotlinVersion = "200.7.0"
 
 ### Android versions
 androidGradlePlugin = "8.7.3"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 # ArcGIS Maps SDK for Kotlin version
-arcgisMapsKotlinVersion = "200.7.0"
+arcgisMapsKotlinVersion = "200.7.0-4549"
 
 ### Android versions
 androidGradlePlugin = "8.7.3"

--- a/samples/augment-reality-to-show-tabletop-scene/src/main/AndroidManifest.xml
+++ b/samples/augment-reality-to-show-tabletop-scene/src/main/AndroidManifest.xml
@@ -4,7 +4,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />
 
-    <!-- Limits app visibility in the Google Play Store to ARCore supported devices
+    <!-- Provide support for ARCore via Google Play Services,
+         by checking to see if device is compatible and ready for AR.
          (https://developers.google.com/ar/devices). -->
     <uses-feature
         android:name="android.hardware.camera.ar"

--- a/samples/augment-reality-to-show-tabletop-scene/src/main/AndroidManifest.xml
+++ b/samples/augment-reality-to-show-tabletop-scene/src/main/AndroidManifest.xml
@@ -6,7 +6,9 @@
 
     <!-- Limits app visibility in the Google Play Store to ARCore supported devices
          (https://developers.google.com/ar/devices). -->
-    <uses-feature android:name="android.hardware.camera.ar" />
+    <uses-feature
+        android:name="android.hardware.camera.ar"
+        android:required="false" />
     <uses-feature
         android:name="android.hardware.camera"
         android:required="true" />

--- a/samples/augment-reality-to-show-tabletop-scene/src/main/AndroidManifest.xml
+++ b/samples/augment-reality-to-show-tabletop-scene/src/main/AndroidManifest.xml
@@ -4,12 +4,6 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />
 
-    <!-- Provide support for ARCore via Google Play Services,
-         by checking to see if device is compatible and ready for AR.
-         (https://developers.google.com/ar/devices). -->
-    <uses-feature
-        android:name="android.hardware.camera.ar"
-        android:required="false" />
     <uses-feature
         android:name="android.hardware.camera"
         android:required="true" />
@@ -26,11 +20,10 @@
                 <action android:name="android.intent.action.MAIN" />
             </intent-filter>
         </activity>
-        <!-- "AR Required" app, requires "Google Play Services for AR" (ARCore)
-             to be installed, as the app does not include any non-AR features. -->
-        <meta-data
-            android:name="com.google.ar.core"
-            android:value="required" />
+        <!-- Provide support for ARCore via Google Play Services,
+             by checking to see if device is compatible and ready for AR.
+             (https://developers.google.com/ar/devices). -->
+        <meta-data android:name="com.google.ar.core" android:value="optional" />
     </application>
 
 </manifest>


### PR DESCRIPTION
## Description
PR to make the AR module an optional module for the sample viewer and add logic to handle the scenario if the device does not support AR. 

## Links and Data
Sample Epic: #[5638](https://devtopia.esri.com/runtime/kotlin/issues/5638)
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/100/