### PR TITLE
Update to gradle 8.14

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -12,8 +13,8 @@ java {
 }
 
 tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }
 

--- a/gradle-plugins/build.gradle.kts
+++ b/gradle-plugins/build.gradle.kts
@@ -18,10 +18,5 @@ gradlePlugin {
 }
 
 dependencies {
-    // `kotlin-dsl` applied here uses embedded Kotlin version 1.9.23 for gradle wrapper 8.9
-    // https://docs.gradle.org/current/userguide/compatibility.html#kotlin
-    // This is needed as newer versions of kotlinx-serialization has been compiled using Kotlin 2.0+
-    // https://github.com/Kotlin/kotlinx.serialization/releases
-    // Sample modules do not use kotlin-dsl, instead uses latest kotlin serialization from libs versions.
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
+    implementation(libs.kotlinx.serialization.json)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 arcgisMapsKotlinVersion = "200.8.0-4564"
 
 ### Android versions
-androidGradlePlugin = "8.7.3"
+androidGradlePlugin = "8.9.2"
 lifecycle = "2.8.7"
 androidTools = "31.9.1"
 appcompat = "1.7.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Nov 04 09:26:16 PST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Description
PR to update gradle version to `8.14` (& fix new deprecation)

## Links and Data

Sample issue: [#5714](https://devtopia.esri.com/runtime/kotlin/issues/5714)
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [x] link: ~~https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/104/~~
  - [x] https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/105/