### PR TITLE
Get Artifactory info from local.properties

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,7 +23,7 @@ val localProperties = java.util.Properties().apply {
 // The Artifactory credentials for the ArcGIS Maps SDK for Kotlin repository.
 // First look for the credentials provided via command line (for CI builds), if not found,
 // take the one defined in local.properties.
-// CI builds pass -PartifactoryURL=${ARTIFACTORY_URL} -PartifactoryUser=${ARTIFACTORY_USER} -PartifactoryPassword=${ARTIFACTORY_PASSWORD}
+// CI builds pass -PartifactoryUrl=${ARTIFACTORY_URL} -PartifactoryUser=${ARTIFACTORY_USER} -PartifactoryPassword=${ARTIFACTORY_PASSWORD}
 val artifactoryUrl: String =
     providers.gradleProperty("artifactoryUrl").orNull
         ?: localProperties.getProperty("artifactoryUrl")
@@ -45,7 +45,7 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         maven { url = uri("https://esri.jfrog.io/artifactory/arcgis") }
-        if (artifactoryUrl != "") {
+        if (!artifactoryUrl.isBlank()) {
             maven {
                 url = java.net.URI(artifactoryUrl)
                 credentials {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,13 +13,47 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
+val localProperties = java.util.Properties().apply {
+    val localPropertiesFile = file("local.properties")
+    if (localPropertiesFile.exists()) {
+        load(localPropertiesFile.inputStream())
+    }
+}
+
+// The Artifactory credentials for the ArcGIS Maps SDK for Kotlin repository.
+// First look for the credentials provided via command line (for CI builds), if not found,
+// take the one defined in local.properties.
+// CI builds pass -PartifactoryURL=${ARTIFACTORY_URL} -PartifactoryUser=${ARTIFACTORY_USER} -PartifactoryPassword=${ARTIFACTORY_PASSWORD}
+val artifactoryUrl: String =
+    providers.gradleProperty("artifactoryUrl").orNull
+        ?: localProperties.getProperty("artifactoryUrl")
+        ?: ""
+
+val artifactoryUsername: String =
+    providers.gradleProperty("artifactoryUsername").orNull
+        ?: localProperties.getProperty("artifactoryUsername")
+        ?: ""
+
+val artifactoryPassword: String =
+    providers.gradleProperty("artifactoryPassword").orNull
+        ?: localProperties.getProperty("artifactoryPassword")
+        ?: ""
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
         mavenCentral()
         maven { url = uri("https://esri.jfrog.io/artifactory/arcgis") }
-        maven { url = uri("https://olympus.esri.com/artifactory/arcgisruntime-repo/") }
+        if (artifactoryUrl != "") {
+            maven {
+                url = java.net.URI(artifactoryUrl)
+                credentials {
+                    username = artifactoryUsername
+                    password = artifactoryPassword
+                }
+            }
+        }
         maven(url = "https://jitpack.io")
     }
 }


### PR DESCRIPTION
## Description
<!--
PR to add a new Kotlin sample _"SAMPLE_NAME"_ in `SAMPLE_CATEGORY` category.
-->

Updates the logic used to set Artifactory information to use command-line parameters first, then local.properties second.

## Links and Data

- [Issue - DevOps](https://devtopia.esri.com/runtime/devops/issues/4181), [Issue - Kotlin](https://devtopia.esri.com/runtime/kotlin/issues/5058)
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [X] link: https://runtime-kotlin.esri.com/view/vTest/job/vtest/job/sampleviewer/106/

## What To Review
<!--
-  Review the code to make sure it is easy to follow like other samples on Android
- `README.md` and `README.metadata.json` files
-->
N/A

## How to Test
<!--
Run the sample on the sample viewer or the repo.
-->
N/A

<!-- OPTIONAL
## To Discuss
-->

<!-- OPTIONAL
## Screenshots
-->
