### PR TITLE
Analyse Network with Subnetwork Trace: use new UtilityNetwork constructor

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 # ArcGIS Maps SDK for Kotlin version
-arcgisMapsKotlinVersion = "200.8.0-4613"
+arcgisMapsKotlinVersion = "200.8.0-4633"
 
 ### Android versions
 androidGradlePlugin = "8.9.2"

--- a/samples/analyze-network-with-subnetwork-trace/src/main/java/com/esri/arcgismaps/sample/analyzenetworkwithsubnetworktrace/MainActivity.kt
+++ b/samples/analyze-network-with-subnetwork-trace/src/main/java/com/esri/arcgismaps/sample/analyzenetworkwithsubnetworktrace/MainActivity.kt
@@ -36,6 +36,7 @@ import com.arcgismaps.Guid
 import com.arcgismaps.LoadStatus
 import com.arcgismaps.data.CodedValue
 import com.arcgismaps.data.CodedValueDomain
+import com.arcgismaps.data.ServiceGeodatabase
 import com.arcgismaps.httpcore.authentication.ArcGISAuthenticationChallengeHandler
 import com.arcgismaps.httpcore.authentication.ArcGISAuthenticationChallengeResponse
 import com.arcgismaps.httpcore.authentication.TokenCredential
@@ -112,7 +113,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private val utilityNetwork by lazy {
-        UtilityNetwork(getString(R.string.utility_network_url))
+        UtilityNetwork(ServiceGeodatabase(getString(R.string.utility_network_url)))
     }
 
     private var initialExpression: UtilityTraceConditionalExpression? = null


### PR DESCRIPTION
## Description
The existing `UtilityNetwork(uri: String)` and `UtilityNetwork(uri: String, map: ArcGISMap)` constructors have been deprecated at 200.8.0.

We have one sample using an old UN constructor, so we should replace that.

## Links and Data
Sample Epic: [#5835](https://devtopia.esri.com/runtime/kotlin/issues/5835)
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/vTest/job/vtest/job/sampleviewer/132/

## What To Review
- Does the sample use the new UN constructor
- Does the sample still work

## How to Test
Run the sample in the sample viewer.

<!-- OPTIONAL
## To Discuss
-->

<!-- OPTIONAL
## Screenshots
-->
