### PR TITLE
AR sample enhancements: handle geospatial API key and show VPS availability

### DIFF
--- a/samples/augment-reality-to-navigate-route/src/main/java/com/esri/arcgismaps/sample/augmentrealitytonavigateroute/MainActivity.kt
+++ b/samples/augment-reality-to-navigate-route/src/main/java/com/esri/arcgismaps/sample/augmentrealitytonavigateroute/MainActivity.kt
@@ -57,9 +57,12 @@ class MainActivity : ComponentActivity() {
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         ArcGISEnvironment.applicationContext = applicationContext
 
-        requestLocationPermission()
+        val hasNonDefaultAPIKey = BuildConfig.GOOGLE_API_KEY != "DEFAULT_GOOGLE_API_KEY"
 
+        SharedRepository.updateHasNonDefaultAPIKey(hasNonDefaultAPIKey)
         SharedRepository.updateRoute(null)
+
+        requestLocationPermission()
     }
 
     private fun requestLocationPermission() {

--- a/samples/augment-reality-to-navigate-route/src/main/java/com/esri/arcgismaps/sample/augmentrealitytonavigateroute/components/AugmentedRealityViewModel.kt
+++ b/samples/augment-reality-to-navigate-route/src/main/java/com/esri/arcgismaps/sample/augmentrealitytonavigateroute/components/AugmentedRealityViewModel.kt
@@ -48,6 +48,8 @@ import com.arcgismaps.navigation.RouteTracker
 import com.arcgismaps.tasks.networkanalysis.DirectionManeuverType
 import com.arcgismaps.tasks.networkanalysis.Route
 import com.arcgismaps.tasks.networkanalysis.RouteResult
+import com.arcgismaps.toolkit.ar.WorldScaleSceneViewProxy
+import com.arcgismaps.toolkit.ar.WorldScaleVpsAvailability
 import com.esri.arcgismaps.sample.augmentrealitytonavigateroute.R
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -58,6 +60,10 @@ import kotlin.math.abs
 import kotlin.math.atan2
 
 class AugmentedRealityViewModel(app: Application) : AndroidViewModel(app) {
+
+    val worldScaleSceneViewProxy = WorldScaleSceneViewProxy()
+
+    var isVpsAvailable by mutableStateOf(false)
 
     // Path to the model file
     val provisionPath: String by lazy {
@@ -421,6 +427,17 @@ class AugmentedRealityViewModel(app: Application) : AndroidViewModel(app) {
                     symbol.depth = 2 * scaleFactor
                     delay(frameDelay)
                 }
+            }
+        }
+    }
+
+    /**
+     * Checks if the current viewpoint camera location is within the VPS availability area.
+     */
+    fun onCurrentViewpointCameraChanged(location: Point) {
+        viewModelScope.launch {
+            worldScaleSceneViewProxy.checkVpsAvailability(location.y, location.x).onSuccess {
+                isVpsAvailable = it == WorldScaleVpsAvailability.Available
             }
         }
     }

--- a/samples/augment-reality-to-navigate-route/src/main/java/com/esri/arcgismaps/sample/augmentrealitytonavigateroute/components/SharedRepository.kt
+++ b/samples/augment-reality-to-navigate-route/src/main/java/com/esri/arcgismaps/sample/augmentrealitytonavigateroute/components/SharedRepository.kt
@@ -31,7 +31,15 @@ object SharedRepository {
     val route
         get() = _route
 
+    private var _hasNonDefaultAPIKey by mutableStateOf(false)
+    val hasNonDefaultAPIKey: Boolean
+        get() = _hasNonDefaultAPIKey
+
     fun updateRoute(route: RouteResult?) {
         _route = route
+    }
+
+    fun updateHasNonDefaultAPIKey(hasNonDefaultAPIKey: Boolean) {
+        _hasNonDefaultAPIKey = hasNonDefaultAPIKey
     }
 }

--- a/samples/augment-reality-to-navigate-route/src/main/java/com/esri/arcgismaps/sample/augmentrealitytonavigateroute/screens/AugmentedRealityScreen.kt
+++ b/samples/augment-reality-to-navigate-route/src/main/java/com/esri/arcgismaps/sample/augmentrealitytonavigateroute/screens/AugmentedRealityScreen.kt
@@ -99,13 +99,8 @@ fun AugmentedRealityScreen(
 
     // Initialize the world scale tracking mode based on whether a google API key is provided
     val initialWorldScaleTrackingMode = when {
-        SharedRepository.hasNonDefaultAPIKey -> {
-            WorldScaleTrackingMode.Geospatial()
-        }
-
-        else -> {
-            WorldScaleTrackingMode.World()
-        }
+        SharedRepository.hasNonDefaultAPIKey -> { WorldScaleTrackingMode.Geospatial() }
+        else -> { WorldScaleTrackingMode.World() }
     }
 
     var trackingMode by remember { mutableStateOf(initialWorldScaleTrackingMode) }

--- a/samples/augment-reality-to-show-hidden-infrastructure/src/main/java/com/esri/arcgismaps/sample/augmentrealitytoshowhiddeninfrastructure/MainActivity.kt
+++ b/samples/augment-reality-to-show-hidden-infrastructure/src/main/java/com/esri/arcgismaps/sample/augmentrealitytoshowhiddeninfrastructure/MainActivity.kt
@@ -57,9 +57,12 @@ class MainActivity : ComponentActivity() {
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         ArcGISEnvironment.applicationContext = applicationContext
 
-        requestLocationPermission()
+        val hasNonDefaultAPIKey = BuildConfig.GOOGLE_API_KEY != "DEFAULT_GOOGLE_API_KEY"
 
+        SharedRepository.updateHasNonDefaultAPIKey(hasNonDefaultAPIKey)
         SharedRepository.pipeInfoList.clear()
+
+        requestLocationPermission()
     }
 
     private fun requestLocationPermission() {

--- a/samples/augment-reality-to-show-hidden-infrastructure/src/main/java/com/esri/arcgismaps/sample/augmentrealitytoshowhiddeninfrastructure/components/AugmentedRealityViewModel.kt
+++ b/samples/augment-reality-to-show-hidden-infrastructure/src/main/java/com/esri/arcgismaps/sample/augmentrealitytoshowhiddeninfrastructure/components/AugmentedRealityViewModel.kt
@@ -17,12 +17,16 @@
 package com.esri.arcgismaps.sample.augmentrealitytoshowhiddeninfrastructure.components
 
 import android.app.Application
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.arcgismaps.Color
 import com.arcgismaps.geometry.GeodeticCurveType
 import com.arcgismaps.geometry.GeometryEngine
 import com.arcgismaps.geometry.LinearUnit
+import com.arcgismaps.geometry.Point
 import com.arcgismaps.geometry.Polyline
 import com.arcgismaps.geometry.PolylineBuilder
 import com.arcgismaps.geometry.SpatialReference
@@ -37,9 +41,15 @@ import com.arcgismaps.mapping.symbology.StrokeSymbolLayerLineStyle3D
 import com.arcgismaps.mapping.view.Graphic
 import com.arcgismaps.mapping.view.GraphicsOverlay
 import com.arcgismaps.mapping.view.SurfacePlacement
+import com.arcgismaps.toolkit.ar.WorldScaleSceneViewProxy
+import com.arcgismaps.toolkit.ar.WorldScaleVpsAvailability
 import kotlinx.coroutines.launch
 
 class AugmentedRealityViewModel(app: Application) : AndroidViewModel(app) {
+
+    val worldScaleSceneViewProxy = WorldScaleSceneViewProxy()
+
+    var isVpsAvailable by mutableStateOf(false)
 
     // Graphics overlay for the 3D pipes
     val pipeGraphicsOverlay = GraphicsOverlay().apply {
@@ -157,6 +167,17 @@ class AugmentedRealityViewModel(app: Application) : AndroidViewModel(app) {
                 )
                 val leaderLine = Polyline(listOf(point, offsetPoint))
                 leaderGraphicsOverlay.graphics.add(Graphic(leaderLine, leaderSymbol))
+            }
+        }
+    }
+
+    /**
+     * Checks if the current viewpoint camera location is within the VPS availability area.
+     */
+    fun onCurrentViewpointCameraChanged(location: Point) {
+        viewModelScope.launch {
+            worldScaleSceneViewProxy.checkVpsAvailability(location.y, location.x).onSuccess {
+                isVpsAvailable = it == WorldScaleVpsAvailability.Available
             }
         }
     }

--- a/samples/augment-reality-to-show-hidden-infrastructure/src/main/java/com/esri/arcgismaps/sample/augmentrealitytoshowhiddeninfrastructure/components/SharedRepository.kt
+++ b/samples/augment-reality-to-show-hidden-infrastructure/src/main/java/com/esri/arcgismaps/sample/augmentrealitytoshowhiddeninfrastructure/components/SharedRepository.kt
@@ -16,6 +16,10 @@
 
 package com.esri.arcgismaps.sample.augmentrealitytoshowhiddeninfrastructure.components
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+
 /**
  * Shared repository to hold the route result generated in the route view model and passed to the augmented reality view
  * model.
@@ -25,6 +29,14 @@ object SharedRepository {
     private var _pipeInfoList: MutableList<PipeInfo> = mutableListOf()
     val pipeInfoList
         get() = _pipeInfoList
+
+    private var _hasNonDefaultAPIKey by mutableStateOf(false)
+    val hasNonDefaultAPIKey: Boolean
+        get() = _hasNonDefaultAPIKey
+
+    fun updateHasNonDefaultAPIKey(hasNonDefaultAPIKey: Boolean) {
+        _hasNonDefaultAPIKey = hasNonDefaultAPIKey
+    }
 }
 
 

--- a/samples/augment-reality-to-show-hidden-infrastructure/src/main/java/com/esri/arcgismaps/sample/augmentrealitytoshowhiddeninfrastructure/screens/AugmentedRealityScreen.kt
+++ b/samples/augment-reality-to-show-hidden-infrastructure/src/main/java/com/esri/arcgismaps/sample/augmentrealitytoshowhiddeninfrastructure/screens/AugmentedRealityScreen.kt
@@ -84,13 +84,8 @@ fun AugmentedRealityScreen(sampleName: String) {
 
     // Initialize the world scale tracking mode based on whether a google API key is provided
     val initialWorldScaleTrackingMode = when {
-        SharedRepository.hasNonDefaultAPIKey -> {
-            WorldScaleTrackingMode.Geospatial()
-        }
-
-        else -> {
-            WorldScaleTrackingMode.World()
-        }
+        SharedRepository.hasNonDefaultAPIKey -> { WorldScaleTrackingMode.Geospatial() }
+        else -> { WorldScaleTrackingMode.World() }
     }
 
     var trackingMode by remember { mutableStateOf(initialWorldScaleTrackingMode) }

--- a/samples/augment-reality-to-show-hidden-infrastructure/src/main/java/com/esri/arcgismaps/sample/augmentrealitytoshowhiddeninfrastructure/screens/AugmentedRealityScreen.kt
+++ b/samples/augment-reality-to-show-hidden-infrastructure/src/main/java/com/esri/arcgismaps/sample/augmentrealitytoshowhiddeninfrastructure/screens/AugmentedRealityScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.LinkAnnotation
@@ -69,6 +70,7 @@ import com.arcgismaps.toolkit.ar.WorldScaleTrackingMode
 import com.arcgismaps.toolkit.ar.rememberWorldScaleSceneViewStatus
 import com.esri.arcgismaps.sample.augmentrealitytoshowhiddeninfrastructure.R
 import com.esri.arcgismaps.sample.augmentrealitytoshowhiddeninfrastructure.components.AugmentedRealityViewModel
+import com.esri.arcgismaps.sample.augmentrealitytoshowhiddeninfrastructure.components.SharedRepository
 import com.esri.arcgismaps.sample.sampleslib.components.SampleTopAppBar
 
 private const val KEY_PREF_ACCEPTED_PRIVACY_INFO = "ACCEPTED_PRIVACY_INFO"
@@ -79,7 +81,19 @@ fun AugmentedRealityScreen(sampleName: String) {
 
     var displayCalibrationView by remember { mutableStateOf(false) }
     var initializationStatus by rememberWorldScaleSceneViewStatus()
-    var trackingMode by remember { mutableStateOf<WorldScaleTrackingMode>(WorldScaleTrackingMode.Geospatial()) }
+
+    // Initialize the world scale tracking mode based on whether a google API key is provided
+    val initialWorldScaleTrackingMode = when {
+        SharedRepository.hasNonDefaultAPIKey -> {
+            WorldScaleTrackingMode.Geospatial()
+        }
+
+        else -> {
+            WorldScaleTrackingMode.World()
+        }
+    }
+
+    var trackingMode by remember { mutableStateOf(initialWorldScaleTrackingMode) }
 
     var showDropdownMenu by remember { mutableStateOf(false) }
     var isPipeShadowVisible by remember { mutableStateOf(true) }
@@ -151,6 +165,12 @@ fun AugmentedRealityScreen(sampleName: String) {
                             augmentedRealityViewModel.pipeShadowGraphicsOverlay,
                             augmentedRealityViewModel.leaderGraphicsOverlay
                         ),
+                        onCurrentViewpointCameraChanged = { camera ->
+                            if (camera.location.x != 0.0 && camera.location.y != 0.0) {
+                                augmentedRealityViewModel.onCurrentViewpointCameraChanged(camera.location)
+                            }
+                        },
+                        worldScaleSceneViewProxy = augmentedRealityViewModel.worldScaleSceneViewProxy,
                         worldScaleTrackingMode = trackingMode,
                         onInitializationStatusChanged = { status ->
                             initializationStatus = status
@@ -171,6 +191,24 @@ fun AugmentedRealityScreen(sampleName: String) {
                         trackingMode = trackingMode,
                         arcGISSceneLoadStatus = augmentedRealityViewModel.arcGISScene.loadStatus.collectAsStateWithLifecycle().value
                     )
+                    if (trackingMode is WorldScaleTrackingMode.Geospatial) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .background(Color.Gray.copy(alpha = 0.5f))
+                                .padding(8.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = if (augmentedRealityViewModel.isVpsAvailable) {
+                                    "VPS available"
+                                } else {
+                                    "VPS unavailable"
+                                },
+                                color = Color.White
+                            )
+                        }
+                    }
                 }
             }
         },


### PR DESCRIPTION
## Description

Enhance AR samples to better handle geospatial API key and VPS availability

## Links and Data

- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/133/

## What To Review

- Does the sample correctly start you in Geospatial or World scale mode with/without a google geospatial API key present?
- Does the UI correctly update when VPS is available (when near google street view data) or not?