### PR TITLE
Change deprecated call for OAuthUserConfiguration

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 # ArcGIS Maps SDK for Kotlin version
-arcgisMapsKotlinVersion = "200.8.0-4656"
+arcgisMapsKotlinVersion = "200.8.0-4662"
 
 ### Android versions
 androidGradlePlugin = "8.9.2"

--- a/samples/authenticate-with-oauth/src/main/java/com/esri/arcgismaps/sample/authenticatewithoauth/components/MapViewModel.kt
+++ b/samples/authenticate-with-oauth/src/main/java/com/esri/arcgismaps/sample/authenticatewithoauth/components/MapViewModel.kt
@@ -34,14 +34,16 @@ class MapViewModel(application: Application) : AndroidViewModel(application) {
     val authenticatorState = AuthenticatorState().apply {
         // Set up OAuth configuration if you want to use OAuth. Leaving the oAuthoUserConfiguration
         // null will instead see the user challenged for credentials in an AlertDialog.
-        oAuthUserConfiguration = OAuthUserConfiguration(
-            "https://www.arcgis.com",
-            // This clientId is a unique identifier associated with an application registered with
-            // the portal. Your app will need its own clientId which you can create here:
-            // https://developers.arcgis.com/documentation/mapping-apis-and-services/security/tutorials/register-your-application/
-            "lgAdHkYZYlwwfAhC",
-            // The URL that the OAuth server will redirect to after the user has authenticated.
-            "authenticate-with-oauth://auth",
+        oAuthUserConfigurations = listOf(
+            OAuthUserConfiguration(
+                "https://www.arcgis.com",
+                // This clientId is a unique identifier associated with an application registered with
+                // the portal. Your app will need its own clientId which you can create here:
+                // https://developers.arcgis.com/documentation/mapping-apis-and-services/security/tutorials/register-your-application/
+                "lgAdHkYZYlwwfAhC",
+                // The URL that the OAuth server will redirect to after the user has authenticated.
+                "authenticate-with-oauth://auth",
+            )
         )
     }
 

--- a/samples/create-and-save-map/src/main/java/com/esri/arcgismaps/sample/createandsavemap/components/MapViewModel.kt
+++ b/samples/create-and-save-map/src/main/java/com/esri/arcgismaps/sample/createandsavemap/components/MapViewModel.kt
@@ -16,17 +16,12 @@
 
 package com.esri.arcgismaps.sample.createandsavemap.components
 
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
-
 import android.app.Application
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.lifecycle.viewModelScope
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.AndroidViewModel
-
+import androidx.lifecycle.viewModelScope
 import com.arcgismaps.httpcore.authentication.OAuthUserConfiguration
 import com.arcgismaps.mapping.ArcGISMap
 import com.arcgismaps.mapping.Basemap
@@ -39,6 +34,9 @@ import com.arcgismaps.portal.PortalFolder
 import com.arcgismaps.toolkit.authentication.AuthenticatorState
 import com.esri.arcgismaps.sample.createandsavemap.R
 import com.esri.arcgismaps.sample.sampleslib.components.MessageDialogViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 
 class MapViewModel(application: Application) : AndroidViewModel(application) {
 
@@ -47,10 +45,12 @@ class MapViewModel(application: Application) : AndroidViewModel(application) {
 
     // set up authenticator state to handle authentication challenges
     val authenticatorState = AuthenticatorState().apply {
-        oAuthUserConfiguration = OAuthUserConfiguration(
-            portalUrl = application.getString(R.string.portal_url),
-            clientId = application.getString(R.string.client_id),
-            redirectUrl = application.getString(R.string.redirect_url)
+        oAuthUserConfigurations = listOf(
+            OAuthUserConfiguration(
+                portalUrl = application.getString(R.string.portal_url),
+                clientId = application.getString(R.string.client_id),
+                redirectUrl = application.getString(R.string.redirect_url)
+            )
         )
     }
 

--- a/samples/show-portal-user-info/src/main/java/com/esri/arcgismaps/sample/showportaluserinfo/components/AppViewModel.kt
+++ b/samples/show-portal-user-info/src/main/java/com/esri/arcgismaps/sample/showportaluserinfo/components/AppViewModel.kt
@@ -97,7 +97,7 @@ class AppViewModel(private val application: Application) : AndroidViewModel(appl
 
     fun loadPortal() = viewModelScope.launch {
         _isLoading.value = true
-        authenticatorState.oAuthUserConfiguration = oAuthUserConfiguration
+        authenticatorState.oAuthUserConfigurations = listOf(oAuthUserConfiguration)
         val portal = Portal(url.value, Portal.Connection.Authenticated)
         portal.load().also {
             _isLoading.value = false


### PR DESCRIPTION
## Description

Replace deprecated oAuth assignment now to by list

## Links and Data

- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [ ] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/142/
