### PR TITLE
Remove use of androidx.lifecycle:lifecycle-runtime-ktx

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,7 +48,6 @@ navigationUiKtx = "2.8.9"
 
 ### Android libs
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
-androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
 androidx-lifecycle-livedata-ktx = { group = "androidx.lifecycle", name = "lifecycle-livedata-ktx", version.ref = "lifecycle" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 commons-io = { group = "commons-io", name = "commons-io", version.ref = "commonsIoVersion" }

--- a/samples-lib/build.gradle.kts
+++ b/samples-lib/build.gradle.kts
@@ -21,7 +21,6 @@ dependencies {
     // Only module specific dependencies needed here
 
     // lib dependencies from rootProject build.gradle
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.constraintlayout)
     implementation(libs.android.material)
     implementation(libs.commons.io)


### PR DESCRIPTION
## Description
<!--
PR to add a new Kotlin sample _"SAMPLE_NAME"_ in `SAMPLE_CATEGORY` category.
-->

Based on [this](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.8.0) "lifecycle-runtime-ktx is now empty, with all APIs being moved into lifecycle-runtime." remove uses of androidx.lifecycle:lifecycle-runtime-ktx 

vTest - https://runtime-kotlin.esri.com/job/200.8.0/job/vtest/job/sampleviewer/1/console
