### PR TITLE
Fix `-D build=200.x` build flag

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
 
     defaultConfig {
         applicationId = "com.esri.arcgismaps.kotlin.sampleviewer"
-        buildConfigField("String", "ARCGIS_VERSION", "\"${rootProject.extra.get("arcgisMapsKotlinVersion")}\"")
+        buildConfigField("String", "ARCGIS_VERSION", "\"${System.getProperty("build") ?: libs.versions.arcgisMapsKotlinVersion}\"")
     }
 
     // Optional input to apply the external signing configuration for the sample viewer

--- a/build-logic/convention/src/main/java/ArcGISMapsKotlinSampleConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/ArcGISMapsKotlinSampleConventionPlugin.kt
@@ -9,14 +9,23 @@ class ArcGISMapsKotlinSampleConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             dependencies {
-                // ArcGIS Maps SDK for Kotlin
-                implementation(libs.findLibrary("arcgis-maps-kotlin").get())
-                // Get the Toolkit BOM
-                implementation(platform(libs.findLibrary("arcgis-maps-kotlin-toolkit-bom").get()))
-                // ArcGIS Maps SDK Toolkit GeoView Compose
-                implementation(libs.findLibrary("arcgis-maps-kotlin-toolkit-geoview-compose").get())
-                // Local project common samples library
-                implementation(project(":samples-lib"))
+                dependencies {
+                    // if a "build" property is set from the command line like: "-D build=200.X.X-XXXX"
+                    val buildVersion = System.getProperty("build")
+                    // Override version in libs.versions.toml file
+                    if (buildVersion != null) {
+                        implementation("com.esri:arcgis-maps-kotlin:$buildVersion")
+                        implementation(platform("com.esri:arcgis-maps-kotlin-toolkit-bom:$buildVersion"))
+                        implementation("com.esri:arcgis-maps-kotlin-toolkit-geoview-compose")
+                    } else {
+                        // Use version catalog when no build flag is provided
+                        implementation(libs.findLibrary("arcgis-maps-kotlin").get())
+                        implementation(platform(libs.findLibrary("arcgis-maps-kotlin-toolkit-bom").get()))
+                        implementation(libs.findLibrary("arcgis-maps-kotlin-toolkit-geoview-compose").get())
+                    }
+                    // Local project common samples library
+                    implementation(project(":samples-lib"))
+                }
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,20 +8,3 @@ plugins {
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.kotlin.serialization) apply false
 }
-
-buildscript {
-    // if a "build" property is set from the command line like: "-D build=100.X.X-XXXX"
-    if (System.getProperty("build") != null) {
-        // override versions in libs.versions.toml file
-        rootProject.extra.apply {
-            set("arcgisMapsKotlinVersion", System.getProperty("build"))
-            set("arcgisToolkitVersion", System.getProperty("build"))
-            set("versionName", System.getProperty("build"))
-        }
-    } else {
-        // use versions in libs.versions.toml file
-        rootProject.extra.apply {
-            set("arcgisMapsKotlinVersion", libs.versions.arcgisMapsKotlinVersion.get())
-        }
-    }
-}


### PR DESCRIPTION
## Description
PR to fix `-D build=200.x` build flag:
```cmd
./gradlew assembleDebug -D build=200.8.0-4665 
```

## Links and Data

Sample issue: [#6228](https://devtopia.esri.com/runtime/kotlin/issues/6228)
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/144/