### PR TITLE
Fix: Samples to use edge to edge

### DIFF
--- a/samples-lib/src/main/java/com/esri/arcgismaps/sample/sampleslib/BaseEdgeToEdgeActivity.kt
+++ b/samples-lib/src/main/java/com/esri/arcgismaps/sample/sampleslib/BaseEdgeToEdgeActivity.kt
@@ -1,0 +1,36 @@
+/* Copyright 2025 Esri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.esri.arcgismaps.sample.sampleslib
+
+import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+
+abstract class BaseEdgeToEdgeActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content)) { v, insets ->
+            // Applies system bar insets (status bar and navigation bar) as padding to the given view.
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
+            insets
+        }
+    }
+}

--- a/samples-lib/src/main/java/com/esri/arcgismaps/sample/sampleslib/EdgeToEdgeCompatActivity.kt
+++ b/samples-lib/src/main/java/com/esri/arcgismaps/sample/sampleslib/EdgeToEdgeCompatActivity.kt
@@ -22,7 +22,13 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 
-abstract class BaseEdgeToEdgeActivity : AppCompatActivity() {
+/**
+ * A base activity designed to enable edge-to-edge display support for devices targeting API 35 and above.
+ * This class extends [AppCompatActivity] and provides a consistent implementation for handling
+ * system bar insets, ensuring proper layout padding for ArcGIS MapsSDK Kotlin samples using
+ * view-based (XML) layouts.
+ */
+abstract class EdgeToEdgeCompatActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()

--- a/samples-lib/src/main/java/com/esri/arcgismaps/sample/sampleslib/components/SampleTopAppBar.kt
+++ b/samples-lib/src/main/java/com/esri/arcgismaps/sample/sampleslib/components/SampleTopAppBar.kt
@@ -16,17 +16,14 @@
 
 package com.esri.arcgismaps.sample.sampleslib.components
 
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import com.esri.arcgismaps.sample.sampleslib.theme.md_theme_dark_primaryContainer
-import com.esri.arcgismaps.sample.sampleslib.theme.md_theme_light_primaryContainer
-
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -35,19 +32,12 @@ fun SampleTopAppBar(
     modifier: Modifier = Modifier,
     actions: @Composable RowScope.() -> Unit = {}
 ) {
-    val containerColor =
-        if (isSystemInDarkTheme()) {
-            md_theme_dark_primaryContainer
-        } else {
-            md_theme_light_primaryContainer
-        }
-
     TopAppBar(
         title = { Text(text = title) },
         actions = actions,
         modifier = modifier,
         colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = containerColor
+            containerColor = MaterialTheme.colorScheme.primaryContainer
         )
     )
 }

--- a/samples-lib/src/main/java/com/esri/arcgismaps/sample/sampleslib/theme/Theme.kt
+++ b/samples-lib/src/main/java/com/esri/arcgismaps/sample/sampleslib/theme/Theme.kt
@@ -16,16 +16,11 @@
 
 package com.esri.arcgismaps.sample.sampleslib.theme
 
-import android.app.Activity
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalView
-import androidx.core.view.WindowCompat
 
 @Composable
 fun SampleAppTheme(
@@ -36,16 +31,6 @@ fun SampleAppTheme(
         LightColors
     } else {
         DarkColors
-    }
-
-    val view = LocalView.current
-    val activity = view.context as? Activity
-    val isLightIcons = colors.onPrimary == Color.White
-
-    SideEffect {
-        activity?.window?.let { window ->
-            WindowCompat.getInsetsController(window, window.decorView).isAppearanceLightStatusBars = isLightIcons
-        }
     }
 
     MaterialTheme(

--- a/samples/add-3d-tiles-layer/src/main/java/com/esri/arcgismaps/sample/add3dtileslayer/MainActivity.kt
+++ b/samples/add-3d-tiles-layer/src/main/java/com/esri/arcgismaps/sample/add3dtileslayer/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.add3dtileslayer
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 Add3DTilesLayerApp()

--- a/samples/add-custom-dynamic-entity-data-source/src/main/java/com/esri/arcgismaps/sample/addcustomdynamicentitydatasource/MainActivity.kt
+++ b/samples/add-custom-dynamic-entity-data-source/src/main/java/com/esri/arcgismaps/sample/addcustomdynamicentitydatasource/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.addcustomdynamicentitydatasource
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 SampleApp()

--- a/samples/add-dynamic-entity-layer/src/main/java/com/esri/arcgismaps/sample/adddynamicentitylayer/MainActivity.kt
+++ b/samples/add-dynamic-entity-layer/src/main/java/com/esri/arcgismaps/sample/adddynamicentitylayer/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.adddynamicentitylayer
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -34,6 +35,7 @@ class MainActivity : ComponentActivity() {
         // authentication with an API key or named user is
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 AddDynamicEntityLayerApp()

--- a/samples/add-enc-exchange-set/src/main/java/com/esri/arcgismaps/sample/addencexchangeset/MainActivity.kt
+++ b/samples/add-enc-exchange-set/src/main/java/com/esri/arcgismaps/sample/addencexchangeset/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.addencexchangeset
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 SampleApp()

--- a/samples/add-feature-layers/src/main/java/com/esri/arcgismaps/sample/addfeaturelayers/MainActivity.kt
+++ b/samples/add-feature-layers/src/main/java/com/esri/arcgismaps/sample/addfeaturelayers/MainActivity.kt
@@ -20,8 +20,7 @@ import android.os.Bundle
 import android.util.Log
 import android.widget.ArrayAdapter
 import android.widget.Toast
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -40,7 +39,7 @@ import com.esri.arcgismaps.sample.addfeaturelayers.databinding.AddFeatureLayersA
 import kotlinx.coroutines.launch
 import java.io.File
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: AddFeatureLayersActivityMainBinding by lazy {
@@ -69,7 +68,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/add-feature-layers/src/main/java/com/esri/arcgismaps/sample/addfeaturelayers/MainActivity.kt
+++ b/samples/add-feature-layers/src/main/java/com/esri/arcgismaps/sample/addfeaturelayers/MainActivity.kt
@@ -20,7 +20,7 @@ import android.os.Bundle
 import android.util.Log
 import android.widget.ArrayAdapter
 import android.widget.Toast
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -39,7 +39,7 @@ import com.esri.arcgismaps.sample.addfeaturelayers.databinding.AddFeatureLayersA
 import kotlinx.coroutines.launch
 import java.io.File
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: AddFeatureLayersActivityMainBinding by lazy {

--- a/samples/add-feature-layers/src/main/res/layout/add_feature_layers_activity_main.xml
+++ b/samples/add-feature-layers/src/main/res/layout/add_feature_layers_activity_main.xml
@@ -6,8 +6,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true">
+        tools:context=".MainActivity">
 
         <com.arcgismaps.mapping.view.MapView
             android:id="@+id/mapView"

--- a/samples/add-features-with-contingent-values/src/main/java/com/esri/arcgismaps/sample/addfeatureswithcontingentvalues/MainActivity.kt
+++ b/samples/add-features-with-contingent-values/src/main/java/com/esri/arcgismaps/sample/addfeatureswithcontingentvalues/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.addfeatureswithcontingentvalues
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 AddFeaturesWithContingentValuesApp()

--- a/samples/add-kml-layer-with-network-links/src/main/java/com/esri/arcgismaps/sample/addkmllayerwithnetworklinks/MainActivity.kt
+++ b/samples/add-kml-layer-with-network-links/src/main/java/com/esri/arcgismaps/sample/addkmllayerwithnetworklinks/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.addkmllayerwithnetworklinks
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 SampleApp()

--- a/samples/add-map-image-layer/src/main/java/com/esri/arcgismaps/sample/addmapimagelayer/MainActivity.kt
+++ b/samples/add-map-image-layer/src/main/java/com/esri/arcgismaps/sample/addmapimagelayer/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.addmapimagelayer
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 AddMapImageLayerApp()

--- a/samples/add-point-scene-layer/src/main/java/com/esri/arcgismaps/sample/addpointscenelayer/MainActivity.kt
+++ b/samples/add-point-scene-layer/src/main/java/com/esri/arcgismaps/sample/addpointscenelayer/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.addpointscenelayer
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 AddPointSceneLayerApp()

--- a/samples/add-raster-from-file/src/main/java/com/esri/arcgismaps/sample/addrasterfromfile/MainActivity.kt
+++ b/samples/add-raster-from-file/src/main/java/com/esri/arcgismaps/sample/addrasterfromfile/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.addrasterfromfile
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 AddRasterFromFileApp()

--- a/samples/add-scene-layer-from-service/src/main/java/com/esri/arcgismaps/sample/addscenelayerfromservice/MainActivity.kt
+++ b/samples/add-scene-layer-from-service/src/main/java/com/esri/arcgismaps/sample/addscenelayerfromservice/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.addscenelayerfromservice
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 AddSceneLayerFromServiceApp()

--- a/samples/add-web-tiled-layer/src/main/java/com/esri/arcgismaps/sample/addwebtiledlayer/MainActivity.kt
+++ b/samples/add-web-tiled-layer/src/main/java/com/esri/arcgismaps/sample/addwebtiledlayer/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.addwebtiledlayer
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 AddWebTiledLayerApp()

--- a/samples/add-wfs-layer/src/main/java/com/esri/arcgismaps/sample/addwfslayer/MainActivity.kt
+++ b/samples/add-wfs-layer/src/main/java/com/esri/arcgismaps/sample/addwfslayer/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.addwfslayer
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 AddWfsLayerApp()

--- a/samples/add-wms-layer/src/main/java/com/esri/arcgismaps/sample/addwmslayer/MainActivity.kt
+++ b/samples/add-wms-layer/src/main/java/com/esri/arcgismaps/sample/addwmslayer/MainActivity.kt
@@ -19,7 +19,7 @@ package com.esri.arcgismaps.sample.addwmslayer
 
 import android.os.Bundle
 import android.util.Log
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -32,7 +32,7 @@ import com.esri.arcgismaps.sample.addwmslayer.databinding.AddWmsLayerActivityMai
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: AddWmsLayerActivityMainBinding by lazy {

--- a/samples/add-wms-layer/src/main/java/com/esri/arcgismaps/sample/addwmslayer/MainActivity.kt
+++ b/samples/add-wms-layer/src/main/java/com/esri/arcgismaps/sample/addwmslayer/MainActivity.kt
@@ -19,8 +19,7 @@ package com.esri.arcgismaps.sample.addwmslayer
 
 import android.os.Bundle
 import android.util.Log
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -33,7 +32,7 @@ import com.esri.arcgismaps.sample.addwmslayer.databinding.AddWmsLayerActivityMai
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: AddWmsLayerActivityMainBinding by lazy {
@@ -46,7 +45,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/add-wms-layer/src/main/res/layout/add_wms_layer_activity_main.xml
+++ b/samples/add-wms-layer/src/main/res/layout/add_wms_layer_activity_main.xml
@@ -4,8 +4,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true">
+        tools:context=".MainActivity">
 
         <com.arcgismaps.mapping.view.MapView
             android:id="@+id/mapView"

--- a/samples/analyze-hotspots/src/main/java/com/esri/arcgismaps/sample/analyzehotspots/MainActivity.kt
+++ b/samples/analyze-hotspots/src/main/java/com/esri/arcgismaps/sample/analyzehotspots/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.analyzehotspots
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 AnalyzeHotspotsApp()

--- a/samples/analyze-network-with-subnetwork-trace/src/main/java/com/esri/arcgismaps/sample/analyzenetworkwithsubnetworktrace/MainActivity.kt
+++ b/samples/analyze-network-with-subnetwork-trace/src/main/java/com/esri/arcgismaps/sample/analyzenetworkwithsubnetworktrace/MainActivity.kt
@@ -28,9 +28,6 @@ import android.widget.RelativeLayout
 import android.widget.TextView
 import android.widget.ToggleButton
 import androidx.appcompat.app.AlertDialog
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ArcGISEnvironment
@@ -60,6 +57,7 @@ import com.arcgismaps.utilitynetworks.UtilityTraceType
 import com.arcgismaps.utilitynetworks.UtilityTraversability
 import com.esri.arcgismaps.sample.analyzenetworkwithsubnetworktrace.databinding.AnalyzeNetworkWithSubnetworkTraceActivityMainBinding
 import com.esri.arcgismaps.sample.analyzenetworkwithsubnetworktrace.databinding.LoadingOptionsDialogBinding
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
@@ -67,7 +65,7 @@ import com.google.android.material.textfield.TextInputEditText
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: AnalyzeNetworkWithSubnetworkTraceActivityMainBinding by lazy {
@@ -132,13 +130,6 @@ class MainActivity : BaseEdgeToEdgeActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content)) { v, insets ->
-            // Applies system bar insets (status bar and navigation bar) as padding to the given view.
-            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
-            insets
-        }
 
         ArcGISEnvironment.applicationContext = this
         ArcGISEnvironment.authenticationManager.arcGISAuthenticationChallengeHandler =

--- a/samples/analyze-network-with-subnetwork-trace/src/main/java/com/esri/arcgismaps/sample/analyzenetworkwithsubnetworktrace/MainActivity.kt
+++ b/samples/analyze-network-with-subnetwork-trace/src/main/java/com/esri/arcgismaps/sample/analyzenetworkwithsubnetworktrace/MainActivity.kt
@@ -28,7 +28,7 @@ import android.widget.RelativeLayout
 import android.widget.TextView
 import android.widget.ToggleButton
 import androidx.appcompat.app.AlertDialog
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.databinding.DataBindingUtil
@@ -67,7 +67,7 @@ import com.google.android.material.textfield.TextInputEditText
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: AnalyzeNetworkWithSubnetworkTraceActivityMainBinding by lazy {

--- a/samples/animate-images-with-image-overlay/src/main/java/com/esri/arcgismaps/sample/animateimageswithimageoverlay/MainActivity.kt
+++ b/samples/animate-images-with-image-overlay/src/main/java/com/esri/arcgismaps/sample/animateimageswithimageoverlay/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.animateimageswithimageoverlay
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 AnimateImagesWithImageOverlayApp()

--- a/samples/apply-class-breaks-renderer-to-sublayer/src/main/java/com/esri/arcgismaps/sample/applyclassbreaksrenderertosublayer/MainActivity.kt
+++ b/samples/apply-class-breaks-renderer-to-sublayer/src/main/java/com/esri/arcgismaps/sample/applyclassbreaksrenderertosublayer/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.applyclassbreaksrenderertosublayer
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ApplyClassBreaksRendererToSublayerApp()

--- a/samples/apply-dictionary-renderer-to-feature-layer/src/main/java/com/esri/arcgismaps/sample/applydictionaryrenderertofeaturelayer/MainActivity.kt
+++ b/samples/apply-dictionary-renderer-to-feature-layer/src/main/java/com/esri/arcgismaps/sample/applydictionaryrenderertofeaturelayer/MainActivity.kt
@@ -18,7 +18,7 @@ package com.esri.arcgismaps.sample.applydictionaryrenderertofeaturelayer
 
 import android.os.Bundle
 import android.util.Log
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -35,7 +35,7 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 import java.io.File
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: ApplyDictionaryRendererToFeatureLayerActivityMainBinding by lazy {

--- a/samples/apply-dictionary-renderer-to-feature-layer/src/main/java/com/esri/arcgismaps/sample/applydictionaryrenderertofeaturelayer/MainActivity.kt
+++ b/samples/apply-dictionary-renderer-to-feature-layer/src/main/java/com/esri/arcgismaps/sample/applydictionaryrenderertofeaturelayer/MainActivity.kt
@@ -18,8 +18,7 @@ package com.esri.arcgismaps.sample.applydictionaryrenderertofeaturelayer
 
 import android.os.Bundle
 import android.util.Log
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -36,7 +35,7 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 import java.io.File
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: ApplyDictionaryRendererToFeatureLayerActivityMainBinding by lazy {
@@ -53,7 +52,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/apply-dictionary-renderer-to-feature-layer/src/main/res/layout/apply_dictionary_renderer_to_feature_layer_activity_main.xml
+++ b/samples/apply-dictionary-renderer-to-feature-layer/src/main/res/layout/apply_dictionary_renderer_to_feature_layer_activity_main.xml
@@ -4,8 +4,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true">
+        tools:context=".MainActivity">
 
         <com.arcgismaps.mapping.view.MapView
             android:id="@+id/mapView"

--- a/samples/apply-function-to-raster-from-service/src/main/java/com/esri/arcgismaps/sample/applyfunctiontorasterfromservice/MainActivity.kt
+++ b/samples/apply-function-to-raster-from-service/src/main/java/com/esri/arcgismaps/sample/applyfunctiontorasterfromservice/MainActivity.kt
@@ -18,8 +18,7 @@ package com.esri.arcgismaps.sample.applyfunctiontorasterfromservice
 
 import android.os.Bundle
 import android.util.Log
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -35,7 +34,7 @@ import com.esri.arcgismaps.sample.applyfunctiontorasterfromservice.databinding.A
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     private val activityMainBinding: ApplyFunctionToRasterFromServiceActivityMainBinding by lazy {
         DataBindingUtil.setContentView(this, R.layout.apply_function_to_raster_from_service_activity_main)
@@ -55,7 +54,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/apply-function-to-raster-from-service/src/main/java/com/esri/arcgismaps/sample/applyfunctiontorasterfromservice/MainActivity.kt
+++ b/samples/apply-function-to-raster-from-service/src/main/java/com/esri/arcgismaps/sample/applyfunctiontorasterfromservice/MainActivity.kt
@@ -18,7 +18,7 @@ package com.esri.arcgismaps.sample.applyfunctiontorasterfromservice
 
 import android.os.Bundle
 import android.util.Log
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -34,7 +34,7 @@ import com.esri.arcgismaps.sample.applyfunctiontorasterfromservice.databinding.A
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     private val activityMainBinding: ApplyFunctionToRasterFromServiceActivityMainBinding by lazy {
         DataBindingUtil.setContentView(this, R.layout.apply_function_to_raster_from_service_activity_main)

--- a/samples/apply-function-to-raster-from-service/src/main/res/layout/apply_function_to_raster_from_service_activity_main.xml
+++ b/samples/apply-function-to-raster-from-service/src/main/res/layout/apply_function_to_raster_from_service_activity_main.xml
@@ -6,8 +6,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true">
+        tools:context=".MainActivity">
 
         <com.arcgismaps.mapping.view.MapView
             android:id="@+id/mapView"

--- a/samples/apply-hillshade-renderer-to-raster/src/main/java/com/esri/arcgismaps/sample/applyhillshaderenderertoraster/MainActivity.kt
+++ b/samples/apply-hillshade-renderer-to-raster/src/main/java/com/esri/arcgismaps/sample/applyhillshaderenderertoraster/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.applyhillshaderenderertoraster
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ApplyHillshadeRendererToRasterApp()

--- a/samples/apply-mosaic-rule-to-rasters/src/main/java/com/esri/arcgismaps/sample/applymosaicruletorasters/MainActivity.kt
+++ b/samples/apply-mosaic-rule-to-rasters/src/main/java/com/esri/arcgismaps/sample/applymosaicruletorasters/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.applymosaicruletorasters
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ApplyMosaicRuleToRastersApp()

--- a/samples/apply-raster-rendering-rule/src/main/java/com/esri/arcgismaps/sample/applyrasterrenderingrule/MainActivity.kt
+++ b/samples/apply-raster-rendering-rule/src/main/java/com/esri/arcgismaps/sample/applyrasterrenderingrule/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.applyrasterrenderingrule
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ApplyRasterRenderingRuleApp()

--- a/samples/apply-scene-property-expressions/src/main/java/com/esri/arcgismaps/sample/applyscenepropertyexpressions/MainActivity.kt
+++ b/samples/apply-scene-property-expressions/src/main/java/com/esri/arcgismaps/sample/applyscenepropertyexpressions/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.applyscenepropertyexpressions
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -36,6 +37,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ApplyScenePropertyExpressionsApp()

--- a/samples/apply-simple-renderer-to-feature-layer/src/main/java/com/esri/arcgismaps/sample/applysimplerenderertofeaturelayer/MainActivity.kt
+++ b/samples/apply-simple-renderer-to-feature-layer/src/main/java/com/esri/arcgismaps/sample/applysimplerenderertofeaturelayer/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.applysimplerenderertofeaturelayer
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ApplySimpleRendererToFeatureLayerApp()

--- a/samples/apply-simple-renderer-to-graphics-overlay/src/main/java/com/esri/arcgismaps/sample/applysimplerenderertographicsoverlay/MainActivity.kt
+++ b/samples/apply-simple-renderer-to-graphics-overlay/src/main/java/com/esri/arcgismaps/sample/applysimplerenderertographicsoverlay/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.applysimplerenderertographicsoverlay
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ApplySimpleRendererToGraphicsOverlayApp()

--- a/samples/augment-reality-to-collect-data/src/main/java/com/esri/arcgismaps/sample/augmentrealitytocollectdata/MainActivity.kt
+++ b/samples/augment-reality-to-collect-data/src/main/java/com/esri/arcgismaps/sample/augmentrealitytocollectdata/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.augmentrealitytocollectdata
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 AugmentRealityToCollectDataApp()

--- a/samples/augment-reality-to-navigate-route/src/main/java/com/esri/arcgismaps/sample/augmentrealitytonavigateroute/MainActivity.kt
+++ b/samples/augment-reality-to-navigate-route/src/main/java/com/esri/arcgismaps/sample/augmentrealitytonavigateroute/MainActivity.kt
@@ -21,6 +21,7 @@ import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.navigation.compose.rememberNavController
@@ -43,6 +44,7 @@ class MainActivity : ComponentActivity() {
             Toast.makeText(this, "Location permission is required to run this sample!", Toast.LENGTH_SHORT).show()
         }
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 AugmentRealityToNavigateRoute(isLocationPermissionGranted)

--- a/samples/augment-reality-to-show-hidden-infrastructure/src/main/java/com/esri/arcgismaps/sample/augmentrealitytoshowhiddeninfrastructure/MainActivity.kt
+++ b/samples/augment-reality-to-show-hidden-infrastructure/src/main/java/com/esri/arcgismaps/sample/augmentrealitytoshowhiddeninfrastructure/MainActivity.kt
@@ -21,6 +21,7 @@ import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.navigation.compose.rememberNavController
@@ -43,6 +44,7 @@ class MainActivity : ComponentActivity() {
             Toast.makeText(this, "Location permission is required to run this sample!", Toast.LENGTH_SHORT).show()
         }
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 AugmentRealityToNavigateRoute(isLocationPermissionGranted)

--- a/samples/augment-reality-to-show-tabletop-scene/src/main/java/com/esri/arcgismaps/sample/augmentrealitytoshowtabletopscene/MainActivity.kt
+++ b/samples/augment-reality-to-show-tabletop-scene/src/main/java/com/esri/arcgismaps/sample/augmentrealitytoshowtabletopscene/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.augmentrealitytoshowtabletopscene
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -42,6 +43,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 DisplaySceneInTabletopARApp()

--- a/samples/authenticate-with-oauth/src/main/java/com/esri/arcgismaps/sample/authenticatewithoauth/MainActivity.kt
+++ b/samples/authenticate-with-oauth/src/main/java/com/esri/arcgismaps/sample/authenticatewithoauth/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.authenticatewithoauth
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -33,6 +34,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 AuthenticateWithOAuthApp()

--- a/samples/browse-building-floors/src/main/java/com/esri/arcgismaps/sample/browsebuildingfloors/MainActivity.kt
+++ b/samples/browse-building-floors/src/main/java/com/esri/arcgismaps/sample/browsebuildingfloors/MainActivity.kt
@@ -26,7 +26,7 @@ import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.TextView
 import androidx.annotation.LayoutRes
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -40,7 +40,7 @@ import com.esri.arcgismaps.sample.browsebuildingfloors.databinding.BrowseBuildin
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: BrowseBuildingFloorsActivityMainBinding by lazy {

--- a/samples/browse-building-floors/src/main/java/com/esri/arcgismaps/sample/browsebuildingfloors/MainActivity.kt
+++ b/samples/browse-building-floors/src/main/java/com/esri/arcgismaps/sample/browsebuildingfloors/MainActivity.kt
@@ -25,9 +25,8 @@ import android.view.ViewGroup
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.TextView
-import androidx.activity.enableEdgeToEdge
 import androidx.annotation.LayoutRes
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -41,7 +40,7 @@ import com.esri.arcgismaps.sample.browsebuildingfloors.databinding.BrowseBuildin
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: BrowseBuildingFloorsActivityMainBinding by lazy {
@@ -58,7 +57,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/browse-building-floors/src/main/res/layout/browse_building_floors_activity_main.xml
+++ b/samples/browse-building-floors/src/main/res/layout/browse_building_floors_activity_main.xml
@@ -6,8 +6,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true">
+        tools:context=".MainActivity">
 
         <com.arcgismaps.mapping.view.MapView
             android:id="@+id/mapView"

--- a/samples/browse-ogc-api-feature-service/src/main/java/com/esri/arcgismaps/sample/browseogcapifeatureservice/MainActivity.kt
+++ b/samples/browse-ogc-api-feature-service/src/main/java/com/esri/arcgismaps/sample/browseogcapifeatureservice/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.browseogcapifeatureservice
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 BrowseOGCAPIFeatureServiceApp()

--- a/samples/change-camera-controller/src/main/java/com/esri/arcgismaps/sample/changecameracontroller/MainActivity.kt
+++ b/samples/change-camera-controller/src/main/java/com/esri/arcgismaps/sample/changecameracontroller/MainActivity.kt
@@ -19,7 +19,7 @@ package com.esri.arcgismaps.sample.changecameracontroller
 import android.os.Bundle
 import android.util.Log
 import android.widget.ArrayAdapter
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -46,7 +46,7 @@ import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: ChangeCameraControllerActivityMainBinding by lazy {

--- a/samples/change-camera-controller/src/main/java/com/esri/arcgismaps/sample/changecameracontroller/MainActivity.kt
+++ b/samples/change-camera-controller/src/main/java/com/esri/arcgismaps/sample/changecameracontroller/MainActivity.kt
@@ -19,8 +19,7 @@ package com.esri.arcgismaps.sample.changecameracontroller
 import android.os.Bundle
 import android.util.Log
 import android.widget.ArrayAdapter
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -47,7 +46,7 @@ import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: ChangeCameraControllerActivityMainBinding by lazy {
@@ -123,7 +122,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/change-camera-controller/src/main/res/layout/change_camera_controller_activity_main.xml
+++ b/samples/change-camera-controller/src/main/res/layout/change_camera_controller_activity_main.xml
@@ -6,8 +6,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true">
+        tools:context=".MainActivity">
 
         <com.arcgismaps.mapping.view.SceneView
             android:id="@+id/sceneView"

--- a/samples/change-viewpoint/src/main/java/com/esri/arcgismaps/sample/changeviewpoint/MainActivity.kt
+++ b/samples/change-viewpoint/src/main/java/com/esri/arcgismaps/sample/changeviewpoint/MainActivity.kt
@@ -18,8 +18,7 @@ package com.esri.arcgismaps.sample.changeviewpoint
 
 import android.os.Bundle
 import android.view.View
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -33,7 +32,7 @@ import com.arcgismaps.mapping.Viewpoint
 import com.esri.arcgismaps.sample.changeviewpoint.databinding.ChangeViewpointActivityMainBinding
 import kotlinx.coroutines.launch
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     private val viewpointScale = 5000.0
 
@@ -48,7 +47,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/change-viewpoint/src/main/java/com/esri/arcgismaps/sample/changeviewpoint/MainActivity.kt
+++ b/samples/change-viewpoint/src/main/java/com/esri/arcgismaps/sample/changeviewpoint/MainActivity.kt
@@ -18,7 +18,7 @@ package com.esri.arcgismaps.sample.changeviewpoint
 
 import android.os.Bundle
 import android.view.View
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -32,7 +32,7 @@ import com.arcgismaps.mapping.Viewpoint
 import com.esri.arcgismaps.sample.changeviewpoint.databinding.ChangeViewpointActivityMainBinding
 import kotlinx.coroutines.launch
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     private val viewpointScale = 5000.0
 

--- a/samples/change-viewpoint/src/main/res/layout/change_viewpoint_activity_main.xml
+++ b/samples/change-viewpoint/src/main/res/layout/change_viewpoint_activity_main.xml
@@ -6,8 +6,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true">
+        tools:context=".MainActivity">
 
         <com.arcgismaps.mapping.view.MapView
             android:id="@+id/mapView"

--- a/samples/clip-geometry/src/main/java/com/esri/arcgismaps/sample/clipgeometry/MainActivity.kt
+++ b/samples/clip-geometry/src/main/java/com/esri/arcgismaps/sample/clipgeometry/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.clipgeometry
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -36,6 +37,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ClipGeometryApp()

--- a/samples/configure-basemap-style-parameters/src/main/java/com/esri/arcgismaps/sample/configurebasemapstyleparameters/MainActivity.kt
+++ b/samples/configure-basemap-style-parameters/src/main/java/com/esri/arcgismaps/sample/configurebasemapstyleparameters/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.configurebasemapstyleparameters
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -34,6 +35,7 @@ class MainActivity : ComponentActivity() {
         // authentication with an API key or named user is
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 SampleApp()

--- a/samples/configure-clusters/src/main/java/com/esri/arcgismaps/sample/configureclusters/MainActivity.kt
+++ b/samples/configure-clusters/src/main/java/com/esri/arcgismaps/sample/configureclusters/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.configureclusters
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ConfigureClustersApp()

--- a/samples/create-and-edit-geometries/src/main/java/com/esri/arcgismaps/sample/createandeditgeometries/MainActivity.kt
+++ b/samples/create-and-edit-geometries/src/main/java/com/esri/arcgismaps/sample/createandeditgeometries/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.createandeditgeometries
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 CreateAndEditGeometriesApp()

--- a/samples/create-and-save-map/src/main/java/com/esri/arcgismaps/sample/createandsavemap/MainActivity.kt
+++ b/samples/create-and-save-map/src/main/java/com/esri/arcgismaps/sample/createandsavemap/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.createandsavemap
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -32,6 +33,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 SampleApp()

--- a/samples/create-convex-hull-around-points/src/main/java/com/esri/arcgismaps/sample/createconvexhullaroundpoints/MainActivity.kt
+++ b/samples/create-convex-hull-around-points/src/main/java/com/esri/arcgismaps/sample/createconvexhullaroundpoints/MainActivity.kt
@@ -19,7 +19,7 @@ package com.esri.arcgismaps.sample.createconvexhullaroundpoints
 
 import android.os.Bundle
 import android.util.Log
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -46,7 +46,7 @@ import com.esri.arcgismaps.sample.createconvexhullaroundpoints.databinding.Creat
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: CreateConvexHullAroundPointsActivityMainBinding by lazy {

--- a/samples/create-convex-hull-around-points/src/main/java/com/esri/arcgismaps/sample/createconvexhullaroundpoints/MainActivity.kt
+++ b/samples/create-convex-hull-around-points/src/main/java/com/esri/arcgismaps/sample/createconvexhullaroundpoints/MainActivity.kt
@@ -19,8 +19,7 @@ package com.esri.arcgismaps.sample.createconvexhullaroundpoints
 
 import android.os.Bundle
 import android.util.Log
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -47,7 +46,7 @@ import com.esri.arcgismaps.sample.createconvexhullaroundpoints.databinding.Creat
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: CreateConvexHullAroundPointsActivityMainBinding by lazy {
@@ -92,7 +91,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/create-convex-hull-around-points/src/main/res/layout/create_convex_hull_around_points_activity_main.xml
+++ b/samples/create-convex-hull-around-points/src/main/res/layout/create_convex_hull_around_points_activity_main.xml
@@ -6,8 +6,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true" >
+        tools:context=".MainActivity" >
 
         <com.arcgismaps.mapping.view.MapView
             android:id="@+id/mapView"

--- a/samples/create-kml-multi-track/src/main/java/com/esri/arcgismaps/sample/createkmlmultitrack/MainActivity.kt
+++ b/samples/create-kml-multi-track/src/main/java/com/esri/arcgismaps/sample/createkmlmultitrack/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.createkmlmultitrack
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 CreateKMLMultiTrackApp()

--- a/samples/create-mobile-geodatabase/src/main/java/com/esri/arcgismaps/sample/createmobilegeodatabase/MainActivity.kt
+++ b/samples/create-mobile-geodatabase/src/main/java/com/esri/arcgismaps/sample/createmobilegeodatabase/MainActivity.kt
@@ -21,8 +21,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import android.widget.TextView
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.core.content.FileProvider
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
@@ -51,7 +50,7 @@ import kotlinx.coroutines.launch
 import java.io.File
 import java.time.Instant
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: CreateMobileGeodatabaseActivityMainBinding by lazy {
@@ -84,7 +83,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/create-mobile-geodatabase/src/main/java/com/esri/arcgismaps/sample/createmobilegeodatabase/MainActivity.kt
+++ b/samples/create-mobile-geodatabase/src/main/java/com/esri/arcgismaps/sample/createmobilegeodatabase/MainActivity.kt
@@ -21,7 +21,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import android.widget.TextView
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.core.content.FileProvider
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
@@ -50,7 +50,7 @@ import kotlinx.coroutines.launch
 import java.io.File
 import java.time.Instant
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: CreateMobileGeodatabaseActivityMainBinding by lazy {

--- a/samples/create-mobile-geodatabase/src/main/res/layout/create_mobile_geodatabase_activity_main.xml
+++ b/samples/create-mobile-geodatabase/src/main/res/layout/create_mobile_geodatabase_activity_main.xml
@@ -6,8 +6,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true">
+        tools:context=".MainActivity">
 
         <com.arcgismaps.mapping.view.MapView
             android:id="@+id/mapView"

--- a/samples/create-planar-and-geodetic-buffers/src/main/java/com/esri/arcgismaps/sample/createplanarandgeodeticbuffers/MainActivity.kt
+++ b/samples/create-planar-and-geodetic-buffers/src/main/java/com/esri/arcgismaps/sample/createplanarandgeodeticbuffers/MainActivity.kt
@@ -19,7 +19,7 @@ package com.esri.arcgismaps.sample.createplanarandgeodeticbuffers
 import android.os.Bundle
 import android.view.View
 import android.widget.TextView
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -46,7 +46,7 @@ import com.google.android.material.slider.Slider
 import kotlinx.coroutines.launch
 import java.util.Locale
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/samples/create-planar-and-geodetic-buffers/src/main/java/com/esri/arcgismaps/sample/createplanarandgeodeticbuffers/MainActivity.kt
+++ b/samples/create-planar-and-geodetic-buffers/src/main/java/com/esri/arcgismaps/sample/createplanarandgeodeticbuffers/MainActivity.kt
@@ -19,8 +19,7 @@ package com.esri.arcgismaps.sample.createplanarandgeodeticbuffers
 import android.os.Bundle
 import android.view.View
 import android.widget.TextView
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -47,11 +46,10 @@ import com.google.android.material.slider.Slider
 import kotlinx.coroutines.launch
 import java.util.Locale
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/create-planar-and-geodetic-buffers/src/main/res/layout/create_planar_and_geodetic_buffers_activity_main.xml
+++ b/samples/create-planar-and-geodetic-buffers/src/main/res/layout/create_planar_and_geodetic_buffers_activity_main.xml
@@ -6,8 +6,7 @@
         android:id="@+id/relativeLayout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true">
+        tools:context=".MainActivity">
 
         <com.arcgismaps.mapping.view.MapView
             android:id="@+id/mapView"

--- a/samples/create-symbol-styles-from-web-styles/src/main/java/com/esri/arcgismaps/sample/createsymbolstylesfromwebstyles/MainActivity.kt
+++ b/samples/create-symbol-styles-from-web-styles/src/main/java/com/esri/arcgismaps/sample/createsymbolstylesfromwebstyles/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.createsymbolstylesfromwebstyles
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 CreateSymbolStylesFromWebStylesApp()

--- a/samples/cut-geometry/src/main/java/com/esri/arcgismaps/sample/cutgeometry/MainActivity.kt
+++ b/samples/cut-geometry/src/main/java/com/esri/arcgismaps/sample/cutgeometry/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.cutgeometry
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 CutGeometryApp()

--- a/samples/display-annotation/src/main/java/com/esri/arcgismaps/sample/displayannotation/MainActivity.kt
+++ b/samples/display-annotation/src/main/java/com/esri/arcgismaps/sample/displayannotation/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.displayannotation
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 DisplayAnnotationApp()

--- a/samples/display-clusters/src/main/java/com/esri/arcgismaps/sample/displayclusters/MainActivity.kt
+++ b/samples/display-clusters/src/main/java/com/esri/arcgismaps/sample/displayclusters/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.displayclusters
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 FeatureReductionApp()

--- a/samples/display-composable-mapview/src/main/java/com/esri/arcgismaps/sample/displaycomposablemapview/MainActivity.kt
+++ b/samples/display-composable-mapview/src/main/java/com/esri/arcgismaps/sample/displaycomposablemapview/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.displaycomposablemapview
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
@@ -39,6 +40,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 Scaffold(topBar = { SampleTopAppBar(getString(R.string.display_composable_map_view_app_name)) }) {

--- a/samples/display-device-location-with-nmea-data-sources/src/main/java/com/esri/arcgismaps/sample/displaydevicelocationwithnmeadatasources/MainActivity.kt
+++ b/samples/display-device-location-with-nmea-data-sources/src/main/java/com/esri/arcgismaps/sample/displaydevicelocationwithnmeadatasources/MainActivity.kt
@@ -20,7 +20,7 @@ import android.os.Bundle
 import android.util.Log
 import android.view.View
 import android.widget.TextView
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
@@ -44,7 +44,7 @@ import java.nio.charset.StandardCharsets
 import java.util.Timer
 import kotlin.concurrent.timerTask
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     private val provisionPath: String by lazy {
         getExternalFilesDir(null)?.path.toString() + File.separator + getString(R.string.display_device_location_with_nmea_data_sources_app_name)

--- a/samples/display-device-location-with-nmea-data-sources/src/main/java/com/esri/arcgismaps/sample/displaydevicelocationwithnmeadatasources/MainActivity.kt
+++ b/samples/display-device-location-with-nmea-data-sources/src/main/java/com/esri/arcgismaps/sample/displaydevicelocationwithnmeadatasources/MainActivity.kt
@@ -20,8 +20,7 @@ import android.os.Bundle
 import android.util.Log
 import android.view.View
 import android.widget.TextView
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
@@ -45,7 +44,7 @@ import java.nio.charset.StandardCharsets
 import java.util.Timer
 import kotlin.concurrent.timerTask
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     private val provisionPath: String by lazy {
         getExternalFilesDir(null)?.path.toString() + File.separator + getString(R.string.display_device_location_with_nmea_data_sources_app_name)
@@ -95,7 +94,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/display-device-location-with-nmea-data-sources/src/main/res/layout/display_device_location_with_nmea_data_sources_activity_main.xml
+++ b/samples/display-device-location-with-nmea-data-sources/src/main/res/layout/display_device_location_with_nmea_data_sources_activity_main.xml
@@ -6,8 +6,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true">
+        tools:context=".MainActivity">
 
         <LinearLayout
             android:id="@+id/linearLayout"

--- a/samples/display-dimensions/src/main/java/com/esri/arcgismaps/sample/displaydimensions/MainActivity.kt
+++ b/samples/display-dimensions/src/main/java/com/esri/arcgismaps/sample/displaydimensions/MainActivity.kt
@@ -18,8 +18,7 @@ package com.esri.arcgismaps.sample.displaydimensions
 
 import android.os.Bundle
 import android.util.Log
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -33,7 +32,7 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 import java.io.File
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     private val provisionPath: String by lazy {
         getExternalFilesDir(null)?.path.toString() + File.separator + getString(R.string.display_dimensions_app_name)
@@ -62,7 +61,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/display-dimensions/src/main/java/com/esri/arcgismaps/sample/displaydimensions/MainActivity.kt
+++ b/samples/display-dimensions/src/main/java/com/esri/arcgismaps/sample/displaydimensions/MainActivity.kt
@@ -18,7 +18,7 @@ package com.esri.arcgismaps.sample.displaydimensions
 
 import android.os.Bundle
 import android.util.Log
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -32,7 +32,7 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 import java.io.File
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     private val provisionPath: String by lazy {
         getExternalFilesDir(null)?.path.toString() + File.separator + getString(R.string.display_dimensions_app_name)

--- a/samples/display-dimensions/src/main/res/layout/display_dimensions_activity_main.xml
+++ b/samples/display-dimensions/src/main/res/layout/display_dimensions_activity_main.xml
@@ -6,8 +6,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true">
+        tools:context=".MainActivity">
 
         <com.arcgismaps.mapping.view.MapView
             android:id="@+id/mapView"

--- a/samples/display-map-from-mobile-map-package/src/main/java/com/esri/arcgismaps/sample/displaymapfrommobilemappackage/MainActivity.kt
+++ b/samples/display-map-from-mobile-map-package/src/main/java/com/esri/arcgismaps/sample/displaymapfrommobilemappackage/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.displaymapfrommobilemappackage
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -34,6 +35,7 @@ class MainActivity : ComponentActivity() {
         // authentication with an API key or named user is
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 DisplayMapFromMobileMapPackageApp()

--- a/samples/display-map-from-portal-item/src/main/java/com/esri/arcgismaps/sample/displaymapfromportalitem/MainActivity.kt
+++ b/samples/display-map-from-portal-item/src/main/java/com/esri/arcgismaps/sample/displaymapfromportalitem/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.displaymapfromportalitem
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 DisplayMapFromPortalItemApp()

--- a/samples/display-map/src/main/java/com/esri/arcgismaps/sample/displaymap/MainActivity.kt
+++ b/samples/display-map/src/main/java/com/esri/arcgismaps/sample/displaymap/MainActivity.kt
@@ -17,8 +17,7 @@
 package com.esri.arcgismaps.sample.displaymap
 
 import android.os.Bundle
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.databinding.DataBindingUtil
 import com.arcgismaps.ApiKey
 import com.arcgismaps.ArcGISEnvironment
@@ -26,11 +25,10 @@ import com.arcgismaps.mapping.ArcGISMap
 import com.arcgismaps.mapping.BasemapStyle
 import com.esri.arcgismaps.sample.displaymap.databinding.DisplayMapActivityMainBinding
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/display-map/src/main/java/com/esri/arcgismaps/sample/displaymap/MainActivity.kt
+++ b/samples/display-map/src/main/java/com/esri/arcgismaps/sample/displaymap/MainActivity.kt
@@ -17,7 +17,7 @@
 package com.esri.arcgismaps.sample.displaymap
 
 import android.os.Bundle
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import com.arcgismaps.ApiKey
 import com.arcgismaps.ArcGISEnvironment
@@ -25,7 +25,7 @@ import com.arcgismaps.mapping.ArcGISMap
 import com.arcgismaps.mapping.BasemapStyle
 import com.esri.arcgismaps.sample.displaymap.databinding.DisplayMapActivityMainBinding
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/samples/display-map/src/main/res/layout/display_map_activity_main.xml
+++ b/samples/display-map/src/main/res/layout/display_map_activity_main.xml
@@ -4,8 +4,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true">
+        tools:context=".MainActivity">
 
         <com.arcgismaps.mapping.view.MapView
             android:id="@+id/mapView"

--- a/samples/display-overview-map/src/main/java/com/esri/arcgismaps/sample/displayoverviewmap/MainActivity.kt
+++ b/samples/display-overview-map/src/main/java/com/esri/arcgismaps/sample/displayoverviewmap/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.displayoverviewmap
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 DisplayOverviewMapApp()

--- a/samples/display-scene-from-mobile-scene-package/src/main/java/com/esri/arcgismaps/sample/displayscenefrommobilescenepackage/MainActivity.kt
+++ b/samples/display-scene-from-mobile-scene-package/src/main/java/com/esri/arcgismaps/sample/displayscenefrommobilescenepackage/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.displayscenefrommobilescenepackage
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 DisplaySceneFromMobileScenePackageApp()

--- a/samples/display-scene/src/main/java/com/esri/arcgismaps/sample/displayscene/MainActivity.kt
+++ b/samples/display-scene/src/main/java/com/esri/arcgismaps/sample/displayscene/MainActivity.kt
@@ -17,7 +17,7 @@
 package com.esri.arcgismaps.sample.displayscene
 
 import android.os.Bundle
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import com.arcgismaps.ApiKey
 import com.arcgismaps.ArcGISEnvironment
@@ -27,7 +27,7 @@ import com.arcgismaps.mapping.BasemapStyle
 import com.arcgismaps.mapping.view.Camera
 import com.esri.arcgismaps.sample.displayscene.databinding.DisplaySceneActivityMainBinding
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: DisplaySceneActivityMainBinding by lazy {

--- a/samples/display-scene/src/main/java/com/esri/arcgismaps/sample/displayscene/MainActivity.kt
+++ b/samples/display-scene/src/main/java/com/esri/arcgismaps/sample/displayscene/MainActivity.kt
@@ -17,8 +17,7 @@
 package com.esri.arcgismaps.sample.displayscene
 
 import android.os.Bundle
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.databinding.DataBindingUtil
 import com.arcgismaps.ApiKey
 import com.arcgismaps.ArcGISEnvironment
@@ -28,7 +27,7 @@ import com.arcgismaps.mapping.BasemapStyle
 import com.arcgismaps.mapping.view.Camera
 import com.esri.arcgismaps.sample.displayscene.databinding.DisplaySceneActivityMainBinding
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: DisplaySceneActivityMainBinding by lazy {
@@ -41,7 +40,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/display-scene/src/main/res/layout/display_scene_activity_main.xml
+++ b/samples/display-scene/src/main/res/layout/display_scene_activity_main.xml
@@ -5,6 +5,5 @@
         android:id="@+id/sceneView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true" />
+        tools:context=".MainActivity" />
 </layout>

--- a/samples/display-web-scene-from-portal-item/src/main/java/com/esri/arcgismaps/sample/displaywebscenefromportalitem/MainActivity.kt
+++ b/samples/display-web-scene-from-portal-item/src/main/java/com/esri/arcgismaps/sample/displaywebscenefromportalitem/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.displaywebscenefromportalitem
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 DisplayWebSceneFromPortalItemApp()

--- a/samples/download-preplanned-map-area/src/main/java/com/esri/arcgismaps/sample/downloadpreplannedmaparea/MainActivity.kt
+++ b/samples/download-preplanned-map-area/src/main/java/com/esri/arcgismaps/sample/downloadpreplannedmaparea/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.downloadpreplannedmaparea
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -46,6 +47,7 @@ class MainActivity : ComponentActivity() {
         // Delete any existing offline maps, to reset sample state
         File(offlineMapPath).deleteRecursively()
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 DownloadPreplannedMapAreaApp()

--- a/samples/download-vector-tiles-to-local-cache/src/main/java/com/esri/arcgismaps/sample/downloadvectortilestolocalcache/MainActivity.kt
+++ b/samples/download-vector-tiles-to-local-cache/src/main/java/com/esri/arcgismaps/sample/downloadvectortilestolocalcache/MainActivity.kt
@@ -20,7 +20,7 @@ import android.os.Bundle
 import android.util.Log
 import android.view.View
 import android.view.ViewGroup
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -50,7 +50,7 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 import java.io.File
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     private val downloadArea: Graphic = Graphic()
     private var hasCurrentJobCompleted: Boolean = true

--- a/samples/download-vector-tiles-to-local-cache/src/main/java/com/esri/arcgismaps/sample/downloadvectortilestolocalcache/MainActivity.kt
+++ b/samples/download-vector-tiles-to-local-cache/src/main/java/com/esri/arcgismaps/sample/downloadvectortilestolocalcache/MainActivity.kt
@@ -20,8 +20,7 @@ import android.os.Bundle
 import android.util.Log
 import android.view.View
 import android.view.ViewGroup
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -51,7 +50,7 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 import java.io.File
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     private val downloadArea: Graphic = Graphic()
     private var hasCurrentJobCompleted: Boolean = true
@@ -84,7 +83,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/download-vector-tiles-to-local-cache/src/main/res/layout/download_vector_tiles_to_local_cache_activity_main.xml
+++ b/samples/download-vector-tiles-to-local-cache/src/main/res/layout/download_vector_tiles_to_local_cache_activity_main.xml
@@ -6,8 +6,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true">
+        tools:context=".MainActivity">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/parentLayout"

--- a/samples/edit-and-sync-features-with-feature-service/src/main/java/com/esri/arcgismaps/sample/editandsyncfeatureswithfeatureservice/MainActivity.kt
+++ b/samples/edit-and-sync-features-with-feature-service/src/main/java/com/esri/arcgismaps/sample/editandsyncfeatureswithfeatureservice/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.editandsyncfeatureswithfeatureservice
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 SampleApp()

--- a/samples/edit-feature-attachments/src/main/java/com/esri/arcgismaps/sample/editfeatureattachments/MainActivity.kt
+++ b/samples/edit-feature-attachments/src/main/java/com/esri/arcgismaps/sample/editfeatureattachments/MainActivity.kt
@@ -27,7 +27,7 @@ import android.util.Log
 import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.core.content.FileProvider
 import androidx.core.graphics.drawable.toDrawable
 import androidx.databinding.DataBindingUtil
@@ -54,7 +54,7 @@ import kotlinx.coroutines.launch
 import java.io.File
 import java.io.FileOutputStream
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     private val activityMainBinding: EditFeatureAttachmentsActivityMainBinding by lazy {
         DataBindingUtil.setContentView(this, R.layout.edit_feature_attachments_activity_main)

--- a/samples/edit-feature-attachments/src/main/java/com/esri/arcgismaps/sample/editfeatureattachments/MainActivity.kt
+++ b/samples/edit-feature-attachments/src/main/java/com/esri/arcgismaps/sample/editfeatureattachments/MainActivity.kt
@@ -25,10 +25,9 @@ import android.os.Bundle
 import android.provider.MediaStore
 import android.util.Log
 import android.view.ViewGroup
-import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.core.content.FileProvider
 import androidx.core.graphics.drawable.toDrawable
 import androidx.databinding.DataBindingUtil
@@ -55,7 +54,7 @@ import kotlinx.coroutines.launch
 import java.io.File
 import java.io.FileOutputStream
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     private val activityMainBinding: EditFeatureAttachmentsActivityMainBinding by lazy {
         DataBindingUtil.setContentView(this, R.layout.edit_feature_attachments_activity_main)
@@ -98,7 +97,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/edit-feature-attachments/src/main/res/layout/edit_feature_attachments_activity_main.xml
+++ b/samples/edit-feature-attachments/src/main/res/layout/edit_feature_attachments_activity_main.xml
@@ -6,8 +6,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true">
+        tools:context=".MainActivity">
 
         <com.arcgismaps.mapping.view.MapView
             android:id="@+id/mapView"

--- a/samples/edit-features-using-feature-forms/src/main/java/com/esri/arcgismaps/sample/editfeaturesusingfeatureforms/MainActivity.kt
+++ b/samples/edit-features-using-feature-forms/src/main/java/com/esri/arcgismaps/sample/editfeaturesusingfeatureforms/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.editfeaturesusingfeatureforms
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.editfeaturesusingfeatureforms.components.MapViewModel
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         ArcGISEnvironment.applicationContext = this
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 val mapViewModel: MapViewModel = viewModel()

--- a/samples/edit-features-with-feature-linked-annotation/src/main/java/com/esri/arcgismaps/sample/editfeatureswithfeaturelinkedannotation/MainActivity.kt
+++ b/samples/edit-features-with-feature-linked-annotation/src/main/java/com/esri/arcgismaps/sample/editfeatureswithfeaturelinkedannotation/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.editfeatureswithfeaturelinkedannotation
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 EditFeaturesWithFeatureLinkedAnnotationApp()

--- a/samples/edit-geometries-with-programmatic-reticle-tool/src/main/java/com/esri/arcgismaps/sample/editgeometrieswithprogrammaticreticletool/MainActivity.kt
+++ b/samples/edit-geometries-with-programmatic-reticle-tool/src/main/java/com/esri/arcgismaps/sample/editgeometrieswithprogrammaticreticletool/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.editgeometrieswithprogrammaticreticletool
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 EditGeometriesWithProgrammaticReticleToolApp()

--- a/samples/filter-features-in-scene/src/main/java/com/esri/arcgismaps/sample/filterfeaturesinscene/MainActivity.kt
+++ b/samples/filter-features-in-scene/src/main/java/com/esri/arcgismaps/sample/filterfeaturesinscene/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.filterfeaturesinscene
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 FilterFeaturesInSceneApp()

--- a/samples/find-address-with-reverse-geocode/src/main/java/com/esri/arcgismaps/sample/findaddresswithreversegeocode/MainActivity.kt
+++ b/samples/find-address-with-reverse-geocode/src/main/java/com/esri/arcgismaps/sample/findaddresswithreversegeocode/MainActivity.kt
@@ -19,7 +19,7 @@ package com.esri.arcgismaps.sample.findaddresswithreversegeocode
 import android.graphics.drawable.BitmapDrawable
 import android.os.Bundle
 import android.util.Log
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
@@ -38,7 +38,7 @@ import com.esri.arcgismaps.sample.findaddresswithreversegeocode.databinding.Find
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     // service url to be provided to the LocatorTask (geocoder)
     private val geocodeServer =

--- a/samples/find-address-with-reverse-geocode/src/main/java/com/esri/arcgismaps/sample/findaddresswithreversegeocode/MainActivity.kt
+++ b/samples/find-address-with-reverse-geocode/src/main/java/com/esri/arcgismaps/sample/findaddresswithreversegeocode/MainActivity.kt
@@ -19,8 +19,7 @@ package com.esri.arcgismaps.sample.findaddresswithreversegeocode
 import android.graphics.drawable.BitmapDrawable
 import android.os.Bundle
 import android.util.Log
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.core.content.ContextCompat
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
@@ -39,7 +38,7 @@ import com.esri.arcgismaps.sample.findaddresswithreversegeocode.databinding.Find
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     // service url to be provided to the LocatorTask (geocoder)
     private val geocodeServer =
@@ -78,7 +77,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/find-address-with-reverse-geocode/src/main/res/layout/find_address_with_reverse_geocode_activity_main.xml
+++ b/samples/find-address-with-reverse-geocode/src/main/res/layout/find_address_with_reverse_geocode_activity_main.xml
@@ -6,8 +6,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true">
+        tools:context=".MainActivity">
 
         <com.arcgismaps.mapping.view.MapView
             android:id="@+id/mapView"

--- a/samples/find-closest-facility-from-point/src/main/java/com/esri/arcgismaps/sample/findclosestfacilityfrompoint/MainActivity.kt
+++ b/samples/find-closest-facility-from-point/src/main/java/com/esri/arcgismaps/sample/findclosestfacilityfrompoint/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.findclosestfacilityfrompoint
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 SampleApp()

--- a/samples/find-nearest-vertex/src/main/java/com/esri/arcgismaps/sample/findnearestvertex/MainActivity.kt
+++ b/samples/find-nearest-vertex/src/main/java/com/esri/arcgismaps/sample/findnearestvertex/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.findnearestvertex
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 FindNearestVertexApp()

--- a/samples/find-route-around-barriers/src/main/java/com/esri/arcgismaps/sample/findroutearoundbarriers/MainActivity.kt
+++ b/samples/find-route-around-barriers/src/main/java/com/esri/arcgismaps/sample/findroutearoundbarriers/MainActivity.kt
@@ -26,8 +26,7 @@ import android.widget.ArrayAdapter
 import android.widget.ImageView
 import android.widget.ListView
 import android.widget.TextView
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.ContextCompat
@@ -65,7 +64,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: FindRouteAroundBarriersActivityMainBinding by lazy {
@@ -161,7 +160,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/find-route-around-barriers/src/main/java/com/esri/arcgismaps/sample/findroutearoundbarriers/MainActivity.kt
+++ b/samples/find-route-around-barriers/src/main/java/com/esri/arcgismaps/sample/findroutearoundbarriers/MainActivity.kt
@@ -26,7 +26,7 @@ import android.widget.ArrayAdapter
 import android.widget.ImageView
 import android.widget.ListView
 import android.widget.TextView
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.ContextCompat
@@ -64,7 +64,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: FindRouteAroundBarriersActivityMainBinding by lazy {

--- a/samples/find-route-around-barriers/src/main/res/layout/find_route_around_barriers_activity_main.xml
+++ b/samples/find-route-around-barriers/src/main/res/layout/find_route_around_barriers_activity_main.xml
@@ -6,8 +6,7 @@
 
     <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:fitsSystemWindows="true">
+        android:layout_height="match_parent">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/mainContainer"

--- a/samples/find-route-in-transport-network/src/main/java/com/esri/arcgismaps/sample/findrouteintransportnetwork/MainActivity.kt
+++ b/samples/find-route-in-transport-network/src/main/java/com/esri/arcgismaps/sample/findrouteintransportnetwork/MainActivity.kt
@@ -19,7 +19,7 @@ package com.esri.arcgismaps.sample.findrouteintransportnetwork
 import android.graphics.drawable.BitmapDrawable
 import android.os.Bundle
 import android.util.Log
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
@@ -54,7 +54,7 @@ import kotlinx.coroutines.launch
 import java.io.File
 import kotlin.math.roundToInt
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: FindRouteInTransportNetworkActivityMainBinding by lazy {

--- a/samples/find-route-in-transport-network/src/main/java/com/esri/arcgismaps/sample/findrouteintransportnetwork/MainActivity.kt
+++ b/samples/find-route-in-transport-network/src/main/java/com/esri/arcgismaps/sample/findrouteintransportnetwork/MainActivity.kt
@@ -19,8 +19,7 @@ package com.esri.arcgismaps.sample.findrouteintransportnetwork
 import android.graphics.drawable.BitmapDrawable
 import android.os.Bundle
 import android.util.Log
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.core.content.ContextCompat
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
@@ -55,7 +54,7 @@ import kotlinx.coroutines.launch
 import java.io.File
 import kotlin.math.roundToInt
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: FindRouteInTransportNetworkActivityMainBinding by lazy {
@@ -97,7 +96,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/find-route-in-transport-network/src/main/res/layout/find_route_in_transport_network_activity_main.xml
+++ b/samples/find-route-in-transport-network/src/main/res/layout/find_route_in_transport_network_activity_main.xml
@@ -6,8 +6,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true">
+        tools:context=".MainActivity">
 
         <com.arcgismaps.mapping.view.MapView
             android:id="@+id/mapView"

--- a/samples/find-route/src/main/java/com/esri/arcgismaps/sample/findroute/MainActivity.kt
+++ b/samples/find-route/src/main/java/com/esri/arcgismaps/sample/findroute/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.findroute
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 FindRouteApp()

--- a/samples/generate-geodatabase-replica-from-feature-service/src/main/java/com/esri/arcgismaps/sample/generategeodatabasereplicafromfeatureservice/MainActivity.kt
+++ b/samples/generate-geodatabase-replica-from-feature-service/src/main/java/com/esri/arcgismaps/sample/generategeodatabasereplicafromfeatureservice/MainActivity.kt
@@ -20,6 +20,7 @@ package com.esri.arcgismaps.sample.generategeodatabasereplicafromfeatureservice
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -37,6 +38,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 GenerateGeodatabaseReplicaFromFeatureServiceApp()

--- a/samples/generate-offline-map-using-android-jetpack-workmanager/src/main/java/com/esri/arcgismaps/sample/generateofflinemapusingandroidjetpackworkmanager/MainActivity.kt
+++ b/samples/generate-offline-map-using-android-jetpack-workmanager/src/main/java/com/esri/arcgismaps/sample/generateofflinemapusingandroidjetpackworkmanager/MainActivity.kt
@@ -23,8 +23,7 @@ import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.view.ViewGroup
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.databinding.DataBindingUtil
@@ -68,7 +67,7 @@ const val notificationIdParameter = "NotificationId"
 // key for the json job file path
 const val jobParameter = "JsonJobPath"
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: GenerateOfflineMapUsingAndroidJetpackWorkmanagerActivityMainBinding by lazy {
@@ -121,7 +120,7 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
+
 
         // request notifications permission
         requestNotificationPermission()

--- a/samples/generate-offline-map-using-android-jetpack-workmanager/src/main/java/com/esri/arcgismaps/sample/generateofflinemapusingandroidjetpackworkmanager/MainActivity.kt
+++ b/samples/generate-offline-map-using-android-jetpack-workmanager/src/main/java/com/esri/arcgismaps/sample/generateofflinemapusingandroidjetpackworkmanager/MainActivity.kt
@@ -23,7 +23,7 @@ import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.view.ViewGroup
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.databinding.DataBindingUtil
@@ -67,7 +67,7 @@ const val notificationIdParameter = "NotificationId"
 // key for the json job file path
 const val jobParameter = "JsonJobPath"
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: GenerateOfflineMapUsingAndroidJetpackWorkmanagerActivityMainBinding by lazy {

--- a/samples/generate-offline-map-using-android-jetpack-workmanager/src/main/res/layout/generate_offline_map_using_android_jetpack_workmanager_activity_main.xml
+++ b/samples/generate-offline-map-using-android-jetpack-workmanager/src/main/res/layout/generate_offline_map_using_android_jetpack_workmanager_activity_main.xml
@@ -6,8 +6,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true">
+        tools:context=".MainActivity">
 
         <com.arcgismaps.mapping.view.MapView
             android:id="@+id/mapView"

--- a/samples/generate-offline-map-with-custom-parameters/src/main/java/com/esri/arcgismaps/sample/generateofflinemapwithcustomparameters/MainActivity.kt
+++ b/samples/generate-offline-map-with-custom-parameters/src/main/java/com/esri/arcgismaps/sample/generateofflinemapwithcustomparameters/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.generateofflinemapwithcustomparameters
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 GenerateOfflineMapWithCustomParametersApp()

--- a/samples/generate-offline-map/src/main/java/com/esri/arcgismaps/sample/generateofflinemap/MainActivity.kt
+++ b/samples/generate-offline-map/src/main/java/com/esri/arcgismaps/sample/generateofflinemap/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.generateofflinemap
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 SampleApp()

--- a/samples/geocode-offline/src/main/java/com/esri/arcgismaps/sample/geocodeoffline/MainActivity.kt
+++ b/samples/geocode-offline/src/main/java/com/esri/arcgismaps/sample/geocodeoffline/MainActivity.kt
@@ -44,12 +44,12 @@ import com.arcgismaps.tasks.geocode.GeocodeParameters
 import com.arcgismaps.tasks.geocode.GeocodeResult
 import com.arcgismaps.tasks.geocode.LocatorTask
 import com.esri.arcgismaps.sample.geocodeoffline.databinding.GeocodeOfflineActivityMainBinding
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 import java.io.File
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: GeocodeOfflineActivityMainBinding by lazy {

--- a/samples/geocode-offline/src/main/java/com/esri/arcgismaps/sample/geocodeoffline/MainActivity.kt
+++ b/samples/geocode-offline/src/main/java/com/esri/arcgismaps/sample/geocodeoffline/MainActivity.kt
@@ -23,8 +23,6 @@ import android.provider.BaseColumns
 import android.util.Log
 import android.view.Menu
 import android.widget.AutoCompleteTextView
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SearchView
 import androidx.core.content.ContextCompat
 import androidx.cursoradapter.widget.SimpleCursorAdapter
@@ -46,11 +44,12 @@ import com.arcgismaps.tasks.geocode.GeocodeParameters
 import com.arcgismaps.tasks.geocode.GeocodeResult
 import com.arcgismaps.tasks.geocode.LocatorTask
 import com.esri.arcgismaps.sample.geocodeoffline.databinding.GeocodeOfflineActivityMainBinding
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 import java.io.File
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: GeocodeOfflineActivityMainBinding by lazy {
@@ -95,7 +94,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/geocode-offline/src/main/java/com/esri/arcgismaps/sample/geocodeoffline/MainActivity.kt
+++ b/samples/geocode-offline/src/main/java/com/esri/arcgismaps/sample/geocodeoffline/MainActivity.kt
@@ -22,7 +22,9 @@ import android.os.Bundle
 import android.provider.BaseColumns
 import android.util.Log
 import android.view.Menu
+import android.view.View
 import android.widget.AutoCompleteTextView
+import android.widget.EditText
 import androidx.appcompat.widget.SearchView
 import androidx.core.content.ContextCompat
 import androidx.cursoradapter.widget.SimpleCursorAdapter
@@ -128,8 +130,17 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.menu, menu)
         val search = menu.findItem(R.id.appSearchBar)
+        val searchView = search.actionView as SearchView
         // set up address search view and listeners
-        setupAddressSearchView(search.actionView as SearchView)
+        setupAddressSearchView(searchView)
+        val surfaceContainerColor = getColor(com.esri.arcgismaps.sample.sampleslib.R.color.colorBackground)
+        val onSurfaceColor = getColor(com.esri.arcgismaps.sample.sampleslib.R.color.textColor)
+        searchView.findViewById<EditText>(androidx.appcompat.R.id.search_src_text).apply {
+            setTextColor(onSurfaceColor)
+        }
+        searchView.findViewById<View>(androidx.appcompat.R.id.search_plate).apply {
+            setBackgroundColor(surfaceContainerColor)
+        }
         return super.onCreateOptionsMenu(menu)
     }
 

--- a/samples/geocode-offline/src/main/res/layout/geocode_offline_activity_main.xml
+++ b/samples/geocode-offline/src/main/res/layout/geocode_offline_activity_main.xml
@@ -6,8 +6,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true">
+        tools:context=".MainActivity">
 
         <com.arcgismaps.mapping.view.MapView
             android:id="@+id/mapView"

--- a/samples/get-elevation-at-point-on-surface/src/main/java/com/esri/arcgismaps/sample/getelevationatpointonsurface/MainActivity.kt
+++ b/samples/get-elevation-at-point-on-surface/src/main/java/com/esri/arcgismaps/sample/getelevationatpointonsurface/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.getelevationatpointonsurface
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 GetElevationAtPointOnSurfaceApp()

--- a/samples/identify-layer-features/src/main/java/com/esri/arcgismaps/sample/identifylayerfeatures/MainActivity.kt
+++ b/samples/identify-layer-features/src/main/java/com/esri/arcgismaps/sample/identifylayerfeatures/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.identifylayerfeatures
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 IdentifyLayerFeaturesApp()

--- a/samples/manage-features/src/main/java/com/esri/arcgismaps/sample/managefeatures/MainActivity.kt
+++ b/samples/manage-features/src/main/java/com/esri/arcgismaps/sample/managefeatures/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.managefeatures
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ManageFeaturesApp()

--- a/samples/manage-operational-layers/src/main/java/com/esri/arcgismaps/sample/manageoperationallayers/MainActivity.kt
+++ b/samples/manage-operational-layers/src/main/java/com/esri/arcgismaps/sample/manageoperationallayers/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.manageoperationallayers
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ManageOperationalLayersApp()

--- a/samples/navigate-route-with-rerouting/src/main/java/com/esri/arcgismaps/sample/navigateroutewithrerouting/MainActivity.kt
+++ b/samples/navigate-route-with-rerouting/src/main/java/com/esri/arcgismaps/sample/navigateroutewithrerouting/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.navigateroutewithrerouting
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 NavigateRouteWithReroutingApp()

--- a/samples/navigate-route/src/main/java/com/esri/arcgismaps/sample/navigateroute/MainActivity.kt
+++ b/samples/navigate-route/src/main/java/com/esri/arcgismaps/sample/navigateroute/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.navigateroute
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 NavigateRouteApp()

--- a/samples/play-kml-tour/src/main/java/com/esri/arcgismaps/sample/playkmltour/MainActivity.kt
+++ b/samples/play-kml-tour/src/main/java/com/esri/arcgismaps/sample/playkmltour/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.playkmltour
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 PlayKMLTourApp()

--- a/samples/project-geometry/src/main/java/com/esri/arcgismaps/sample/projectgeometry/MainActivity.kt
+++ b/samples/project-geometry/src/main/java/com/esri/arcgismaps/sample/projectgeometry/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.projectgeometry
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ProjectGeometryApp()

--- a/samples/query-feature-table/src/main/java/com/esri/arcgismaps/sample/queryfeaturetable/MainActivity.kt
+++ b/samples/query-feature-table/src/main/java/com/esri/arcgismaps/sample/queryfeaturetable/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.queryfeaturetable
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 QueryFeatureTableApp()

--- a/samples/query-features-with-arcade-expression/src/main/java/com/esri/arcgismaps/sample/queryfeatureswitharcadeexpression/MainActivity.kt
+++ b/samples/query-features-with-arcade-expression/src/main/java/com/esri/arcgismaps/sample/queryfeatureswitharcadeexpression/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.queryfeatureswitharcadeexpression
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 QueryFeaturesWithArcadeExpressionApp()

--- a/samples/render-multilayer-symbols/src/main/java/com/esri/arcgismaps/sample/rendermultilayersymbols/MainActivity.kt
+++ b/samples/render-multilayer-symbols/src/main/java/com/esri/arcgismaps/sample/rendermultilayersymbols/MainActivity.kt
@@ -19,8 +19,7 @@ package com.esri.arcgismaps.sample.rendermultilayersymbols
 import android.graphics.BitmapFactory
 import android.os.Bundle
 import android.util.Log
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.core.graphics.drawable.toDrawable
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
@@ -72,7 +71,7 @@ private val Color.Companion.magenta: Color
 // define offset used to keep a consistent distance between symbols in the same column
 private const val OFFSET = 20.0
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: RenderMultilayerSymbolsActivityMainBinding by lazy {
@@ -88,7 +87,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/render-multilayer-symbols/src/main/java/com/esri/arcgismaps/sample/rendermultilayersymbols/MainActivity.kt
+++ b/samples/render-multilayer-symbols/src/main/java/com/esri/arcgismaps/sample/rendermultilayersymbols/MainActivity.kt
@@ -19,7 +19,7 @@ package com.esri.arcgismaps.sample.rendermultilayersymbols
 import android.graphics.BitmapFactory
 import android.os.Bundle
 import android.util.Log
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.core.graphics.drawable.toDrawable
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
@@ -71,7 +71,7 @@ private val Color.Companion.magenta: Color
 // define offset used to keep a consistent distance between symbols in the same column
 private const val OFFSET = 20.0
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: RenderMultilayerSymbolsActivityMainBinding by lazy {

--- a/samples/render-multilayer-symbols/src/main/res/layout/render_multilayer_symbols_activity_main.xml
+++ b/samples/render-multilayer-symbols/src/main/res/layout/render_multilayer_symbols_activity_main.xml
@@ -4,8 +4,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true">
+        tools:context=".MainActivity">
 
         <com.arcgismaps.mapping.view.MapView
             android:id="@+id/mapView"

--- a/samples/search-with-geocode/src/main/java/com/esri/arcgismaps/sample/searchwithgeocode/MainActivity.kt
+++ b/samples/search-with-geocode/src/main/java/com/esri/arcgismaps/sample/searchwithgeocode/MainActivity.kt
@@ -24,9 +24,10 @@ import android.provider.BaseColumns
 import android.text.SpannableStringBuilder
 import android.util.Log
 import android.view.Menu
+import android.view.View
 import android.view.inputmethod.InputMethodManager
+import android.widget.EditText
 import android.widget.TextView
-import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.appcompat.widget.SearchView
 import androidx.core.content.ContextCompat
 import androidx.core.text.bold
@@ -47,6 +48,7 @@ import com.arcgismaps.mapping.view.ScreenCoordinate
 import com.arcgismaps.tasks.geocode.GeocodeParameters
 import com.arcgismaps.tasks.geocode.GeocodeResult
 import com.arcgismaps.tasks.geocode.LocatorTask
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import com.esri.arcgismaps.sample.searchwithgeocode.databinding.SearchWithGeocodeActivityMainBinding
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.switchmaterial.SwitchMaterial
@@ -140,8 +142,17 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.menu, menu)
         val search = menu.findItem(R.id.appSearchBar)
+        val searchView = search.actionView as SearchView
         // set up address search view and listeners
-        setupAddressSearchView(search.actionView as SearchView)
+        setupAddressSearchView(searchView)
+        val surfaceContainerColor = getColor(com.esri.arcgismaps.sample.sampleslib.R.color.colorBackground)
+        val onSurfaceColor = getColor(com.esri.arcgismaps.sample.sampleslib.R.color.textColor)
+        searchView.findViewById<EditText>(androidx.appcompat.R.id.search_src_text).apply {
+            setTextColor(onSurfaceColor)
+        }
+        searchView.findViewById<View>(androidx.appcompat.R.id.search_plate).apply {
+            setBackgroundColor(surfaceContainerColor)
+        }
         return super.onCreateOptionsMenu(menu)
     }
 

--- a/samples/search-with-geocode/src/main/java/com/esri/arcgismaps/sample/searchwithgeocode/MainActivity.kt
+++ b/samples/search-with-geocode/src/main/java/com/esri/arcgismaps/sample/searchwithgeocode/MainActivity.kt
@@ -26,7 +26,7 @@ import android.util.Log
 import android.view.Menu
 import android.view.inputmethod.InputMethodManager
 import android.widget.TextView
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.appcompat.widget.SearchView
 import androidx.core.content.ContextCompat
 import androidx.core.text.bold
@@ -52,7 +52,7 @@ import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.switchmaterial.SwitchMaterial
 import kotlinx.coroutines.launch
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: SearchWithGeocodeActivityMainBinding by lazy {

--- a/samples/search-with-geocode/src/main/java/com/esri/arcgismaps/sample/searchwithgeocode/MainActivity.kt
+++ b/samples/search-with-geocode/src/main/java/com/esri/arcgismaps/sample/searchwithgeocode/MainActivity.kt
@@ -26,8 +26,7 @@ import android.util.Log
 import android.view.Menu
 import android.view.inputmethod.InputMethodManager
 import android.widget.TextView
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.appcompat.widget.SearchView
 import androidx.core.content.ContextCompat
 import androidx.core.text.bold
@@ -53,7 +52,7 @@ import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.switchmaterial.SwitchMaterial
 import kotlinx.coroutines.launch
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: SearchWithGeocodeActivityMainBinding by lazy {
@@ -94,7 +93,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/search-with-geocode/src/main/res/layout/search_with_geocode_activity_main.xml
+++ b/samples/search-with-geocode/src/main/res/layout/search_with_geocode_activity_main.xml
@@ -6,8 +6,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true">
+        tools:context=".MainActivity">
 
         <com.arcgismaps.mapping.view.MapView
             android:id="@+id/mapView"

--- a/samples/select-features-in-feature-layer/src/main/java/com/esri/arcgismaps/sample/selectfeaturesinfeaturelayer/MainActivity.kt
+++ b/samples/select-features-in-feature-layer/src/main/java/com/esri/arcgismaps/sample/selectfeaturesinfeaturelayer/MainActivity.kt
@@ -31,12 +31,12 @@ import com.arcgismaps.mapping.BasemapStyle
 import com.arcgismaps.mapping.Viewpoint
 import com.arcgismaps.mapping.layers.FeatureLayer
 import com.arcgismaps.mapping.view.ScreenCoordinate
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import com.esri.arcgismaps.sample.selectfeaturesinfeaturelayer.databinding.SelectFeaturesInFeatureLayerActivityMainBinding
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: SelectFeaturesInFeatureLayerActivityMainBinding by lazy {

--- a/samples/select-features-in-feature-layer/src/main/java/com/esri/arcgismaps/sample/selectfeaturesinfeaturelayer/MainActivity.kt
+++ b/samples/select-features-in-feature-layer/src/main/java/com/esri/arcgismaps/sample/selectfeaturesinfeaturelayer/MainActivity.kt
@@ -18,8 +18,6 @@ package com.esri.arcgismaps.sample.selectfeaturesinfeaturelayer
 
 import android.os.Bundle
 import android.util.Log
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -33,11 +31,12 @@ import com.arcgismaps.mapping.BasemapStyle
 import com.arcgismaps.mapping.Viewpoint
 import com.arcgismaps.mapping.layers.FeatureLayer
 import com.arcgismaps.mapping.view.ScreenCoordinate
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import com.esri.arcgismaps.sample.selectfeaturesinfeaturelayer.databinding.SelectFeaturesInFeatureLayerActivityMainBinding
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: SelectFeaturesInFeatureLayerActivityMainBinding by lazy {
@@ -57,7 +56,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/select-features-in-feature-layer/src/main/res/layout/select_features_in_feature_layer_activity_main.xml
+++ b/samples/select-features-in-feature-layer/src/main/res/layout/select_features_in_feature_layer_activity_main.xml
@@ -7,6 +7,5 @@
         android:id="@+id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true" />
+        tools:context=".MainActivity" />
 </layout>

--- a/samples/set-feature-request-mode/src/main/java/com/esri/arcgismaps/sample/setfeaturerequestmode/MainActivity.kt
+++ b/samples/set-feature-request-mode/src/main/java/com/esri/arcgismaps/sample/setfeaturerequestmode/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.setfeaturerequestmode
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 SetFeatureRequestModeApp()

--- a/samples/set-max-extent/src/main/java/com/esri/arcgismaps/sample/setmaxextent/MainActivity.kt
+++ b/samples/set-max-extent/src/main/java/com/esri/arcgismaps/sample/setmaxextent/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.setmaxextent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 SetMaxExtentApp()

--- a/samples/set-up-location-driven-geotriggers/src/main/java/com/esri/arcgismaps/sample/setuplocationdrivengeotriggers/MainActivity.kt
+++ b/samples/set-up-location-driven-geotriggers/src/main/java/com/esri/arcgismaps/sample/setuplocationdrivengeotriggers/MainActivity.kt
@@ -20,8 +20,7 @@ package com.esri.arcgismaps.sample.setuplocationdrivengeotriggers
 import android.os.Bundle
 import android.util.Log
 import android.widget.Toast
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -54,7 +53,7 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 import java.time.Instant
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: SetUpLocationDrivenGeotriggersActivityMainBinding by lazy {
@@ -118,7 +117,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/set-up-location-driven-geotriggers/src/main/java/com/esri/arcgismaps/sample/setuplocationdrivengeotriggers/MainActivity.kt
+++ b/samples/set-up-location-driven-geotriggers/src/main/java/com/esri/arcgismaps/sample/setuplocationdrivengeotriggers/MainActivity.kt
@@ -20,7 +20,7 @@ package com.esri.arcgismaps.sample.setuplocationdrivengeotriggers
 import android.os.Bundle
 import android.util.Log
 import android.widget.Toast
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -53,7 +53,7 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 import java.time.Instant
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: SetUpLocationDrivenGeotriggersActivityMainBinding by lazy {

--- a/samples/set-up-location-driven-geotriggers/src/main/res/layout/set_up_location_driven_geotriggers_activity_main.xml
+++ b/samples/set-up-location-driven-geotriggers/src/main/res/layout/set_up_location_driven_geotriggers_activity_main.xml
@@ -5,8 +5,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:fitsSystemWindows="true">
+        android:layout_height="match_parent">
 
         <com.arcgismaps.mapping.view.MapView
             android:id="@+id/mapView"

--- a/samples/set-viewpoint-rotation/src/main/java/com/esri/arcgismaps/sample/setviewpointrotation/MainActivity.kt
+++ b/samples/set-viewpoint-rotation/src/main/java/com/esri/arcgismaps/sample/setviewpointrotation/MainActivity.kt
@@ -17,7 +17,7 @@
 package com.esri.arcgismaps.sample.setviewpointrotation
 
 import android.os.Bundle
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -28,7 +28,7 @@ import com.arcgismaps.mapping.Viewpoint
 import com.esri.arcgismaps.sample.setviewpointrotation.databinding.SetViewpointRotationActivityMainBinding
 import kotlinx.coroutines.launch
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/samples/set-viewpoint-rotation/src/main/java/com/esri/arcgismaps/sample/setviewpointrotation/MainActivity.kt
+++ b/samples/set-viewpoint-rotation/src/main/java/com/esri/arcgismaps/sample/setviewpointrotation/MainActivity.kt
@@ -17,8 +17,7 @@
 package com.esri.arcgismaps.sample.setviewpointrotation
 
 import android.os.Bundle
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -29,11 +28,10 @@ import com.arcgismaps.mapping.Viewpoint
 import com.esri.arcgismaps.sample.setviewpointrotation.databinding.SetViewpointRotationActivityMainBinding
 import kotlinx.coroutines.launch
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/set-viewpoint-rotation/src/main/res/layout/set_viewpoint_rotation_activity_main.xml
+++ b/samples/set-viewpoint-rotation/src/main/res/layout/set_viewpoint_rotation_activity_main.xml
@@ -6,8 +6,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true">
+        tools:context=".MainActivity">
 
         <com.arcgismaps.mapping.view.MapView
             android:id="@+id/mapView"

--- a/samples/show-callout/src/main/java/com/esri/arcgismaps/sample/showcallout/MainActivity.kt
+++ b/samples/show-callout/src/main/java/com/esri/arcgismaps/sample/showcallout/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.showcallout
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ShowCalloutApp()

--- a/samples/show-coordinates-in-multiple-formats/src/main/java/com/esri/arcgismaps/sample/showcoordinatesinmultipleformats/MainActivity.kt
+++ b/samples/show-coordinates-in-multiple-formats/src/main/java/com/esri/arcgismaps/sample/showcoordinatesinmultipleformats/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.showcoordinatesinmultipleformats
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -38,6 +39,7 @@ class MainActivity : ComponentActivity() {
         // remove focus from text fields when keyboard closes
         WindowCompat.setDecorFitsSystemWindows(window, false)
         // set compose content
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ShowCoordinatesInMultipleFormatsApp()

--- a/samples/show-device-location-using-fused-location-data-source/src/main/java/com/esri/arcgismaps/sample/showdevicelocationusingfusedlocationdatasource/MainActivity.kt
+++ b/samples/show-device-location-using-fused-location-data-source/src/main/java/com/esri/arcgismaps/sample/showdevicelocationusingfusedlocationdatasource/MainActivity.kt
@@ -21,6 +21,7 @@ import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -42,6 +43,7 @@ class MainActivity : ComponentActivity() {
         } else {
             Toast.makeText(this, "Location permission is required to run this sample!", Toast.LENGTH_SHORT).show()
         }
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ShowDeviceLocationUsingFusedLocationDataSource()

--- a/samples/show-device-location-using-indoor-positioning/src/main/java/com/esri/arcgismaps/sample/showdevicelocationusingindoorpositioning/MainActivity.kt
+++ b/samples/show-device-location-using-indoor-positioning/src/main/java/com/esri/arcgismaps/sample/showdevicelocationusingindoorpositioning/MainActivity.kt
@@ -23,8 +23,7 @@ import android.os.Bundle
 import android.util.Log
 import android.view.View
 import android.widget.Toast
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.databinding.DataBindingUtil
@@ -44,7 +43,7 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 import java.text.DecimalFormat
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: ShowDeviceLocationUsingIndoorPositioningActivityMainBinding by lazy {
@@ -71,7 +70,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         lifecycle.addObserver(mapView)
         // some parts of the API require an Android Context to properly interact with Android system

--- a/samples/show-device-location-using-indoor-positioning/src/main/java/com/esri/arcgismaps/sample/showdevicelocationusingindoorpositioning/MainActivity.kt
+++ b/samples/show-device-location-using-indoor-positioning/src/main/java/com/esri/arcgismaps/sample/showdevicelocationusingindoorpositioning/MainActivity.kt
@@ -23,7 +23,7 @@ import android.os.Bundle
 import android.util.Log
 import android.view.View
 import android.widget.Toast
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.databinding.DataBindingUtil
@@ -43,7 +43,7 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 import java.text.DecimalFormat
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: ShowDeviceLocationUsingIndoorPositioningActivityMainBinding by lazy {

--- a/samples/show-device-location-using-indoor-positioning/src/main/res/layout/show_device_location_using_indoor_positioning_activity_main.xml
+++ b/samples/show-device-location-using-indoor-positioning/src/main/res/layout/show_device_location_using_indoor_positioning_activity_main.xml
@@ -6,8 +6,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true">
+        tools:context=".MainActivity">
 
         <com.arcgismaps.mapping.view.MapView
             android:id="@+id/mapView"

--- a/samples/show-device-location/src/main/java/com/esri/arcgismaps/sample/showdevicelocation/MainActivity.kt
+++ b/samples/show-device-location/src/main/java/com/esri/arcgismaps/sample/showdevicelocation/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.showdevicelocation
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ShowDeviceLocationApp()

--- a/samples/show-geodesic-path-between-two-points/src/main/java/com/esri/arcgismaps/sample/showgeodesicpathbetweentwopoints/MainActivity.kt
+++ b/samples/show-geodesic-path-between-two-points/src/main/java/com/esri/arcgismaps/sample/showgeodesicpathbetweentwopoints/MainActivity.kt
@@ -19,8 +19,7 @@ package com.esri.arcgismaps.sample.showgeodesicpathbetweentwopoints
 
 import android.os.Bundle
 import android.util.Log
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -47,7 +46,7 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: ShowGeodesicPathBetweenTwoPointsActivityMainBinding by lazy {
@@ -98,7 +97,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/show-geodesic-path-between-two-points/src/main/java/com/esri/arcgismaps/sample/showgeodesicpathbetweentwopoints/MainActivity.kt
+++ b/samples/show-geodesic-path-between-two-points/src/main/java/com/esri/arcgismaps/sample/showgeodesicpathbetweentwopoints/MainActivity.kt
@@ -19,7 +19,7 @@ package com.esri.arcgismaps.sample.showgeodesicpathbetweentwopoints
 
 import android.os.Bundle
 import android.util.Log
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -46,7 +46,7 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: ShowGeodesicPathBetweenTwoPointsActivityMainBinding by lazy {

--- a/samples/show-geodesic-path-between-two-points/src/main/res/layout/show_geodesic_path_between_two_points_activity_main.xml
+++ b/samples/show-geodesic-path-between-two-points/src/main/res/layout/show_geodesic_path_between_two_points_activity_main.xml
@@ -6,8 +6,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true">
+        tools:context=".MainActivity">
 
         <com.arcgismaps.mapping.view.MapView
             android:id="@+id/mapView"

--- a/samples/show-grid/src/main/java/com/esri/arcgismaps/sample/showgrid/MainActivity.kt
+++ b/samples/show-grid/src/main/java/com/esri/arcgismaps/sample/showgrid/MainActivity.kt
@@ -20,8 +20,7 @@ import android.os.Bundle
 import android.util.Log
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.databinding.DataBindingUtil
 import com.arcgismaps.ApiKey
 import com.arcgismaps.ArcGISEnvironment
@@ -49,7 +48,7 @@ import com.google.android.material.button.MaterialButton
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: ShowGridActivityMainBinding by lazy {
@@ -89,7 +88,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/show-grid/src/main/java/com/esri/arcgismaps/sample/showgrid/MainActivity.kt
+++ b/samples/show-grid/src/main/java/com/esri/arcgismaps/sample/showgrid/MainActivity.kt
@@ -20,7 +20,7 @@ import android.os.Bundle
 import android.util.Log
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import com.arcgismaps.ApiKey
 import com.arcgismaps.ArcGISEnvironment
@@ -48,7 +48,7 @@ import com.google.android.material.button.MaterialButton
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: ShowGridActivityMainBinding by lazy {

--- a/samples/show-grid/src/main/res/layout/show_grid_activity_main.xml
+++ b/samples/show-grid/src/main/res/layout/show_grid_activity_main.xml
@@ -6,8 +6,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true">
+        tools:context=".MainActivity">
 
         <com.arcgismaps.mapping.view.MapView
             android:id="@+id/mapView"

--- a/samples/show-labels-on-layer/src/main/java/com/esri/arcgismaps/sample/showlabelsonlayer/MainActivity.kt
+++ b/samples/show-labels-on-layer/src/main/java/com/esri/arcgismaps/sample/showlabelsonlayer/MainActivity.kt
@@ -19,7 +19,7 @@ package com.esri.arcgismaps.sample.showlabelsonlayer
 
 import android.os.Bundle
 import android.util.Log
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -38,7 +38,7 @@ import com.esri.arcgismaps.sample.showlabelsonlayer.databinding.ShowLabelsOnLaye
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: ShowLabelsOnLayerActivityMainBinding by lazy {

--- a/samples/show-labels-on-layer/src/main/java/com/esri/arcgismaps/sample/showlabelsonlayer/MainActivity.kt
+++ b/samples/show-labels-on-layer/src/main/java/com/esri/arcgismaps/sample/showlabelsonlayer/MainActivity.kt
@@ -19,8 +19,7 @@ package com.esri.arcgismaps.sample.showlabelsonlayer
 
 import android.os.Bundle
 import android.util.Log
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -39,7 +38,7 @@ import com.esri.arcgismaps.sample.showlabelsonlayer.databinding.ShowLabelsOnLaye
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: ShowLabelsOnLayerActivityMainBinding by lazy {
@@ -52,7 +51,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/show-labels-on-layer/src/main/res/layout/show_labels_on_layer_activity_main.xml
+++ b/samples/show-labels-on-layer/src/main/res/layout/show_labels_on_layer_activity_main.xml
@@ -4,8 +4,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true">
+        tools:context=".MainActivity">
 
         <com.arcgismaps.mapping.view.MapView
             android:id="@+id/mapView"

--- a/samples/show-line-of-sight-between-geoelements/src/main/java/com/esri/arcgismaps/sample/showlineofsightbetweengeoelements/MainActivity.kt
+++ b/samples/show-line-of-sight-between-geoelements/src/main/java/com/esri/arcgismaps/sample/showlineofsightbetweengeoelements/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.showlineofsightbetweengeoelements
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 SampleApp()

--- a/samples/show-location-history/src/main/java/com/esri/arcgismaps/sample/showlocationhistory/MainActivity.kt
+++ b/samples/show-location-history/src/main/java/com/esri/arcgismaps/sample/showlocationhistory/MainActivity.kt
@@ -17,7 +17,7 @@
 package com.esri.arcgismaps.sample.showlocationhistory
 
 import android.os.Bundle
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -46,7 +46,7 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 import java.time.Instant
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     private var isTrackLocation: Boolean = false
 

--- a/samples/show-location-history/src/main/java/com/esri/arcgismaps/sample/showlocationhistory/MainActivity.kt
+++ b/samples/show-location-history/src/main/java/com/esri/arcgismaps/sample/showlocationhistory/MainActivity.kt
@@ -17,8 +17,7 @@
 package com.esri.arcgismaps.sample.showlocationhistory
 
 import android.os.Bundle
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -47,7 +46,7 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 import java.time.Instant
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     private var isTrackLocation: Boolean = false
 
@@ -62,7 +61,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/show-location-history/src/main/res/layout/show_location_history_activity_main.xml
+++ b/samples/show-location-history/src/main/res/layout/show_location_history_activity_main.xml
@@ -5,8 +5,7 @@
         xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true">
+        tools:context=".MainActivity">
 
         <com.arcgismaps.mapping.view.MapView
             android:id="@+id/mapView"

--- a/samples/show-magnifier/src/main/java/com/esri/arcgismaps/sample/showmagnifier/MainActivity.kt
+++ b/samples/show-magnifier/src/main/java/com/esri/arcgismaps/sample/showmagnifier/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.showmagnifier
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ShowMagnifierApp()

--- a/samples/show-popup/src/main/java/com/esri/arcgismaps/sample/showpopup/MainActivity.kt
+++ b/samples/show-popup/src/main/java/com/esri/arcgismaps/sample/showpopup/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.showpopup
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -34,7 +35,7 @@ class MainActivity : ComponentActivity() {
         // authentication with an API key or named user is
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
-
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ShowPopupApp()

--- a/samples/show-portal-user-info/src/main/java/com/esri/arcgismaps/sample/showportaluserinfo/MainActivity.kt
+++ b/samples/show-portal-user-info/src/main/java/com/esri/arcgismaps/sample/showportaluserinfo/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.showportaluserinfo
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -29,6 +30,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ShowPortalUserInfoApp()

--- a/samples/show-realistic-light-and-shadows/src/main/java/com/esri/arcgismaps/sample/showrealisticlightandshadows/MainActivity.kt
+++ b/samples/show-realistic-light-and-shadows/src/main/java/com/esri/arcgismaps/sample/showrealisticlightandshadows/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.showrealisticlightandshadows
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ShowRealisticLightAndShadowsApp()

--- a/samples/show-result-of-spatial-operations/src/main/java/com/esri/arcgismaps/sample/showresultofspatialoperations/MainActivity.kt
+++ b/samples/show-result-of-spatial-operations/src/main/java/com/esri/arcgismaps/sample/showresultofspatialoperations/MainActivity.kt
@@ -18,7 +18,7 @@ package com.esri.arcgismaps.sample.showresultofspatialoperations
 
 import android.os.Bundle
 import android.widget.ArrayAdapter
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -47,7 +47,7 @@ private val Color.Companion.blue: Color
         return fromRgba(0, 0, 255, 255)
     }
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: ShowResultOfSpatialOperationsActivityMainBinding by lazy {

--- a/samples/show-result-of-spatial-operations/src/main/java/com/esri/arcgismaps/sample/showresultofspatialoperations/MainActivity.kt
+++ b/samples/show-result-of-spatial-operations/src/main/java/com/esri/arcgismaps/sample/showresultofspatialoperations/MainActivity.kt
@@ -18,8 +18,7 @@ package com.esri.arcgismaps.sample.showresultofspatialoperations
 
 import android.os.Bundle
 import android.widget.ArrayAdapter
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -48,7 +47,7 @@ private val Color.Companion.blue: Color
         return fromRgba(0, 0, 255, 255)
     }
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: ShowResultOfSpatialOperationsActivityMainBinding by lazy {
@@ -85,7 +84,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/show-result-of-spatial-operations/src/main/res/layout/show_result_of_spatial_operations_activity_main.xml
+++ b/samples/show-result-of-spatial-operations/src/main/res/layout/show_result_of_spatial_operations_activity_main.xml
@@ -6,8 +6,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true">
+        tools:context=".MainActivity">
 
         <com.arcgismaps.mapping.view.MapView
             android:id="@+id/mapView"

--- a/samples/show-result-of-spatial-relationships/src/main/java/com/esri/arcgismaps/sample/showresultofspatialrelationships/MainActivity.kt
+++ b/samples/show-result-of-spatial-relationships/src/main/java/com/esri/arcgismaps/sample/showresultofspatialrelationships/MainActivity.kt
@@ -18,8 +18,7 @@ package com.esri.arcgismaps.sample.showresultofspatialrelationships
 
 import android.os.Bundle
 import android.util.Log
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -51,7 +50,7 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: ShowResultOfSpatialRelationshipsActivityMainBinding by lazy {
@@ -119,7 +118,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/show-result-of-spatial-relationships/src/main/java/com/esri/arcgismaps/sample/showresultofspatialrelationships/MainActivity.kt
+++ b/samples/show-result-of-spatial-relationships/src/main/java/com/esri/arcgismaps/sample/showresultofspatialrelationships/MainActivity.kt
@@ -18,7 +18,7 @@ package com.esri.arcgismaps.sample.showresultofspatialrelationships
 
 import android.os.Bundle
 import android.util.Log
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.arcgismaps.ApiKey
@@ -50,7 +50,7 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: ShowResultOfSpatialRelationshipsActivityMainBinding by lazy {

--- a/samples/show-result-of-spatial-relationships/src/main/res/layout/show_result_of_spatial_relationships_activity_main.xml
+++ b/samples/show-result-of-spatial-relationships/src/main/res/layout/show_result_of_spatial_relationships_activity_main.xml
@@ -6,8 +6,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true">
+        tools:context=".MainActivity">
 
         <com.arcgismaps.mapping.view.MapView
             android:id="@+id/mapView"

--- a/samples/show-scale-bar/src/main/java/com/esri/arcgismaps/sample/showscalebar/MainActivity.kt
+++ b/samples/show-scale-bar/src/main/java/com/esri/arcgismaps/sample/showscalebar/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.showscalebar
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ShowScaleBarApp()

--- a/samples/show-service-area/src/main/java/com/esri/arcgismaps/sample/showservicearea/MainActivity.kt
+++ b/samples/show-service-area/src/main/java/com/esri/arcgismaps/sample/showservicearea/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.showservicearea
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         ArcGISEnvironment.applicationContext = this
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ShowServiceAreaApp()

--- a/samples/show-viewshed-from-point-in-scene/src/main/java/com/esri/arcgismaps/sample/showviewshedfrompointinscene/MainActivity.kt
+++ b/samples/show-viewshed-from-point-in-scene/src/main/java/com/esri/arcgismaps/sample/showviewshedfrompointinscene/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.showviewshedfrompointinscene
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ViewshedLocationApp()

--- a/samples/show-viewshed-from-point-on-map/src/main/java/com/esri/arcgismaps/sample/showviewshedfrompointonmap/MainActivity.kt
+++ b/samples/show-viewshed-from-point-on-map/src/main/java/com/esri/arcgismaps/sample/showviewshedfrompointonmap/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.showviewshedfrompointonmap
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ShowViewshedFromPointOnMapApp()

--- a/samples/snap-geometry-edits-with-utility-network-rules/src/main/java/com/esri/arcgismaps/sample/snapgeometryeditswithutilitynetworkrules/MainActivity.kt
+++ b/samples/snap-geometry-edits-with-utility-network-rules/src/main/java/com/esri/arcgismaps/sample/snapgeometryeditswithutilitynetworkrules/MainActivity.kt
@@ -21,6 +21,7 @@ import android.content.pm.ActivityInfo
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -39,6 +40,7 @@ class MainActivity : ComponentActivity() {
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 SnapGeometryEditsWithUtilityNetworkRulesApp()

--- a/samples/snap-geometry-edits/src/main/java/com/esri/arcgismaps/sample/snapgeometryedits/MainActivity.kt
+++ b/samples/snap-geometry-edits/src/main/java/com/esri/arcgismaps/sample/snapgeometryedits/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.snapgeometryedits
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 SampleApp()

--- a/samples/style-graphics-with-renderer/src/main/java/com/esri/arcgismaps/sample/stylegraphicswithrenderer/MainActivity.kt
+++ b/samples/style-graphics-with-renderer/src/main/java/com/esri/arcgismaps/sample/stylegraphicswithrenderer/MainActivity.kt
@@ -17,8 +17,7 @@
 package com.esri.arcgismaps.sample.stylegraphicswithrenderer
 
 import android.os.Bundle
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.databinding.DataBindingUtil
 import com.arcgismaps.ApiKey
 import com.arcgismaps.ArcGISEnvironment
@@ -50,7 +49,7 @@ import com.arcgismaps.mapping.view.Graphic
 import com.arcgismaps.mapping.view.GraphicsOverlay
 import com.esri.arcgismaps.sample.stylegraphicswithrenderer.databinding.StyleGraphicsWithRendererActivityMainBinding
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: StyleGraphicsWithRendererActivityMainBinding by lazy {
@@ -63,7 +62,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/style-graphics-with-renderer/src/main/java/com/esri/arcgismaps/sample/stylegraphicswithrenderer/MainActivity.kt
+++ b/samples/style-graphics-with-renderer/src/main/java/com/esri/arcgismaps/sample/stylegraphicswithrenderer/MainActivity.kt
@@ -17,7 +17,7 @@
 package com.esri.arcgismaps.sample.stylegraphicswithrenderer
 
 import android.os.Bundle
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import com.arcgismaps.ApiKey
 import com.arcgismaps.ArcGISEnvironment
@@ -49,7 +49,7 @@ import com.arcgismaps.mapping.view.Graphic
 import com.arcgismaps.mapping.view.GraphicsOverlay
 import com.esri.arcgismaps.sample.stylegraphicswithrenderer.databinding.StyleGraphicsWithRendererActivityMainBinding
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     // set up data binding for the activity
     private val activityMainBinding: StyleGraphicsWithRendererActivityMainBinding by lazy {

--- a/samples/style-graphics-with-renderer/src/main/res/layout/style_graphics_with_renderer_activity_main.xml
+++ b/samples/style-graphics-with-renderer/src/main/res/layout/style_graphics_with_renderer_activity_main.xml
@@ -4,8 +4,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true">
+        tools:context=".MainActivity">
 
         <com.arcgismaps.mapping.view.MapView
             android:id="@+id/mapView"

--- a/samples/style-graphics-with-symbols/src/main/java/com/esri/arcgismaps/sample/stylegraphicswithsymbols/MainActivity.kt
+++ b/samples/style-graphics-with-symbols/src/main/java/com/esri/arcgismaps/sample/stylegraphicswithsymbols/MainActivity.kt
@@ -17,8 +17,7 @@
 package com.esri.arcgismaps.sample.stylegraphicswithsymbols
 
 import android.os.Bundle
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
 import androidx.databinding.DataBindingUtil
 import com.arcgismaps.ApiKey
 import com.arcgismaps.ArcGISEnvironment
@@ -45,11 +44,10 @@ import com.arcgismaps.mapping.view.Graphic
 import com.arcgismaps.mapping.view.GraphicsOverlay
 import com.esri.arcgismaps.sample.stylegraphicswithsymbols.databinding.StyleGraphicsWithSymbolsActivityMainBinding
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseEdgeToEdgeActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         // authentication with an API key or named user is
         // required to access basemaps and other location services

--- a/samples/style-graphics-with-symbols/src/main/java/com/esri/arcgismaps/sample/stylegraphicswithsymbols/MainActivity.kt
+++ b/samples/style-graphics-with-symbols/src/main/java/com/esri/arcgismaps/sample/stylegraphicswithsymbols/MainActivity.kt
@@ -17,7 +17,7 @@
 package com.esri.arcgismaps.sample.stylegraphicswithsymbols
 
 import android.os.Bundle
-import com.esri.arcgismaps.sample.sampleslib.BaseEdgeToEdgeActivity
+import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import com.arcgismaps.ApiKey
 import com.arcgismaps.ArcGISEnvironment
@@ -44,7 +44,7 @@ import com.arcgismaps.mapping.view.Graphic
 import com.arcgismaps.mapping.view.GraphicsOverlay
 import com.esri.arcgismaps.sample.stylegraphicswithsymbols.databinding.StyleGraphicsWithSymbolsActivityMainBinding
 
-class MainActivity : BaseEdgeToEdgeActivity() {
+class MainActivity : EdgeToEdgeCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/samples/style-graphics-with-symbols/src/main/res/layout/style_graphics_with_symbols_activity_main.xml
+++ b/samples/style-graphics-with-symbols/src/main/res/layout/style_graphics_with_symbols_activity_main.xml
@@ -5,6 +5,5 @@
         android:id="@+id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity"
-        android:fitsSystemWindows="true" />
+        tools:context=".MainActivity" />
 </layout>

--- a/samples/take-screenshot/src/main/java/com/esri/arcgismaps/sample/takescreenshot/MainActivity.kt
+++ b/samples/take-screenshot/src/main/java/com/esri/arcgismaps/sample/takescreenshot/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.takescreenshot
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 TakeScreenshotApp()

--- a/samples/trace-utility-network/src/main/java/com/esri/arcgismaps/sample/traceutilitynetwork/MainActivity.kt
+++ b/samples/trace-utility-network/src/main/java/com/esri/arcgismaps/sample/traceutilitynetwork/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.traceutilitynetwork
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -36,6 +37,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 TraceUtilityNetworkApp()

--- a/samples/validate-utility-network-topology/src/main/java/com/esri/arcgismaps/sample/validateutilitynetworktopology/MainActivity.kt
+++ b/samples/validate-utility-network-topology/src/main/java/com/esri/arcgismaps/sample/validateutilitynetworktopology/MainActivity.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.validateutilitynetworktopology
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         // required to access basemaps and other location services
         ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ValidateUtilityNetworkTopologyApp()


### PR DESCRIPTION
## Description
Add support for a `EdgeToEdgeCompatActivity` for XML samples. Add support to use `enableEdgeToEdge` for all Compose samples. (Not just the sample viewer). 

## Changes made:

- Revert the changes added in  #378 
- Manually apply window insets for all XML samples, and update the each XML sample activity to use `EdgeToEdgeCompatActivity `
- Depend on `enableEdgeToEdge()` for all Compose samples, and add the import in each sample's activity. 
- Optimize color settings for the `SampleTopAppBar`.
- Remove manual `isAppearanceLightStatusBars`, to instead let `enableEdgeToEdge()` set edges/status bar colors for Compose samples. 
- Fix theming issues when using AppCompat searchview in (2) XML samples. 

## Links and Data
Sample issue: [#6240](https://devtopia.esri.com/runtime/kotlin/issues/6240)
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [x] link: ~~https://runtime-kotlin.esri.com/view/Release/job/200.8.0/job/vtest/job/sampleviewer/2/~~
  - [x] https://runtime-kotlin.esri.com/view/Release/job/200.8.0/job/vtest/job/sampleviewer/3/