### PR TITLE
Remove unused permission declaration

### DIFF
--- a/samples/augment-reality-to-navigate-route/src/main/AndroidManifest.xml
+++ b/samples/augment-reality-to-navigate-route/src/main/AndroidManifest.xml
@@ -5,7 +5,6 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 
     <application>
         <activity

--- a/samples/augment-reality-to-show-hidden-infrastructure/src/main/AndroidManifest.xml
+++ b/samples/augment-reality-to-show-hidden-infrastructure/src/main/AndroidManifest.xml
@@ -5,7 +5,6 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 
     <application>
         <activity


### PR DESCRIPTION
## Description
PR to remove unused permission declaration `ACCESS_BACKGROUND_LOCATION` from the sample viewer.