### PR TITLE
Take screenshot permission fix

### DIFF
--- a/samples/take-screenshot/src/main/AndroidManifest.xml
+++ b/samples/take-screenshot/src/main/AndroidManifest.xml
@@ -2,8 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <!-- Required for Android 13+ (reading images) -->
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
 
     <application>
 

--- a/samples/take-screenshot/src/main/java/com/esri/arcgismaps/sample/takescreenshot/screens/TakeScreenshotScreen.kt
+++ b/samples/take-screenshot/src/main/java/com/esri/arcgismaps/sample/takescreenshot/screens/TakeScreenshotScreen.kt
@@ -58,11 +58,11 @@ import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.arcgismaps.toolkit.geoviewcompose.MapView
-import com.esri.arcgismaps.sample.takescreenshot.components.TakeScreenshotViewModel
 import com.esri.arcgismaps.sample.sampleslib.components.MessageDialog
 import com.esri.arcgismaps.sample.sampleslib.components.SampleDialog
 import com.esri.arcgismaps.sample.sampleslib.components.SampleTopAppBar
 import com.esri.arcgismaps.sample.takescreenshot.R
+import com.esri.arcgismaps.sample.takescreenshot.components.TakeScreenshotViewModel
 
 /**
  * Main screen layout for the sample app
@@ -199,7 +199,7 @@ fun SaveImageButton(context: Context, bitmap: Bitmap, saveBitmapToGallery: (Cont
     ) { isGranted ->
         if (isGranted) {
             saveBitmapToGallery(context, bitmap)
-            showToast(context, "Image saved!")
+            showToast(context, "Image saved to Photos gallery!")
         } else {
             showToast(context, "Permission denied")
         }
@@ -209,7 +209,7 @@ fun SaveImageButton(context: Context, bitmap: Bitmap, saveBitmapToGallery: (Cont
         // If permission is null (i.e., running on API > 28), or if permission is already granted
         if (permission == null || ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED) {
             saveBitmapToGallery(context, bitmap)
-            showToast(context, "Image saved!")
+            showToast(context, "Image saved to Photos gallery!")
         } else {
             permissionLauncher.launch(permission)
         }

--- a/samples/take-screenshot/src/main/java/com/esri/arcgismaps/sample/takescreenshot/screens/TakeScreenshotScreen.kt
+++ b/samples/take-screenshot/src/main/java/com/esri/arcgismaps/sample/takescreenshot/screens/TakeScreenshotScreen.kt
@@ -19,6 +19,7 @@ package com.esri.arcgismaps.sample.takescreenshot.screens
 import android.Manifest
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Build
@@ -54,6 +55,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.arcgismaps.toolkit.geoviewcompose.MapView
 import com.esri.arcgismaps.sample.takescreenshot.components.TakeScreenshotViewModel
@@ -188,8 +190,8 @@ fun shareImage(context: Context, imageUri: Uri) {
 @Composable
 fun SaveImageButton(context: Context, bitmap: Bitmap, saveBitmapToGallery: (Context, Bitmap) -> Uri?) {
 
-    val permission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        Manifest.permission.READ_MEDIA_IMAGES
+    val permission = if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
+        Manifest.permission.WRITE_EXTERNAL_STORAGE
     } else null
 
     val permissionLauncher = rememberLauncherForActivityResult(
@@ -204,7 +206,8 @@ fun SaveImageButton(context: Context, bitmap: Bitmap, saveBitmapToGallery: (Cont
     }
 
     TextButton(onClick = {
-        if (permission == null) {
+        // If permission is null (i.e., running on API > 28), or if permission is already granted
+        if (permission == null || ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED) {
             saveBitmapToGallery(context, bitmap)
             showToast(context, "Image saved!")
         } else {


### PR DESCRIPTION
## Description

PR to update the sample Take Screenshot to only use `WRITE_EXTERNAL_STORAGE` permission for API 28. See [Android docs](https://developer.android.com/about/versions/14/changes/partial-photo-video-access). 

> As of Android 10 (API level 29), apps no longer need storage permissions to add files to shared storage. This means that apps can add images to the gallery, record videos and save them to shared storage, or download PDF invoices without having to request storage permissions. If your app only adds files to shared storage and doesn't query images or videos, you should stop requesting storage permissions and set a maxSdkVersion of API 28 in your AndroidManifest.xml: