### PR TITLE
Post-release update to use 300.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Overview
 
-ArcGIS Maps SDK for Kotlin v200.8.0 samples.  The `main` branch of this repository contains sample app modules for the latest available version of the [ArcGIS Maps Kotlin SDK](https://developers.arcgis.com/kotlin/). Samples released under older versions can be found through the [git tags](https://github.com/Esri/arcgis-maps-sdk-kotlin-samples/tags).  Please read our [wiki](https://github.com/Esri/arcgis-maps-sdk-kotlin-samples/wiki) for help with working with this repository.
+ArcGIS Maps SDK for Kotlin v300.0.0 samples.  The `main` branch of this repository contains sample app modules for the latest available version of the [ArcGIS Maps Kotlin SDK](https://developers.arcgis.com/kotlin/). Samples released under older versions can be found through the [git tags](https://github.com/Esri/arcgis-maps-sdk-kotlin-samples/tags).  Please read our [wiki](https://github.com/Esri/arcgis-maps-sdk-kotlin-samples/wiki) for help with working with this repository.
 
 ## Prerequisites
 

--- a/build-logic/convention/src/main/java/ArcGISMapsKotlinSampleConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/ArcGISMapsKotlinSampleConventionPlugin.kt
@@ -10,7 +10,7 @@ class ArcGISMapsKotlinSampleConventionPlugin : Plugin<Project> {
         with(target) {
             dependencies {
                 dependencies {
-                    // if a "build" property is set from the command line like: "-D build=200.X.X-XXXX"
+                    // if a "build" property is set from the command line like: "-D build=300.X.X-XXXX"
                     val buildVersion = System.getProperty("build")
                     // Override version in libs.versions.toml file
                     if (buildVersion != null) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 # ArcGIS Maps SDK for Kotlin version
-arcgisMapsKotlinVersion = "200.8.0"
+arcgisMapsKotlinVersion = "300.0.0-4676"
 
 ### Android versions
 androidGradlePlugin = "8.9.2"


### PR DESCRIPTION
## Description
PR to update `libs.versions.toml` to use 300.x for local development.  

## Links and Data
Sample issue: [#6271](https://devtopia.esri.com/runtime/kotlin/issues/6271)
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/148/