### PR TITLE
Add redirect to add-scene-layer-from-service

### DIFF
--- a/samples/add-scene-layer-from-service/README.metadata.json
+++ b/samples/add-scene-layer-from-service/README.metadata.json
@@ -20,7 +20,7 @@
         "Surface"
     ],
     "language": "kotlin",
-    "redirect_from": "",
+    "redirect_from": ["kotlin/sample-code/add-scene-layer-with-elevation/"],
     "relevant_apis": [
         "ArcGISScene",
         "ArcGISSceneLayer",


### PR DESCRIPTION
## Description

PR to add redirect to add-scene-layer-from-service:


Test an example Kotlin redirect on [CreateAndEditGeometries](https://github.com/Esri/arcgis-maps-sdk-kotlin-samples/blob/main/samples/create-and-edit-geometries/README.metadata.json#L25): 
- https://developers.arcgis.com/kotlin/sample-code/sketch-on-map/
- https://developers.arcgis.com/kotlin/sample-code/create-and-edit-geometries/