### PR TITLE
Update SV to handle v300 deprecations 

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 # ArcGIS Maps SDK for Kotlin version
-arcgisMapsKotlinVersion = "300.0.0-4676"
+arcgisMapsKotlinVersion = "300.0.0-4689"
 
 ### Android versions
 androidGradlePlugin = "8.9.2"

--- a/samples/configure-basemap-style-parameters/src/main/java/com/esri/arcgismaps/sample/configurebasemapstyleparameters/components/MapViewModel.kt
+++ b/samples/configure-basemap-style-parameters/src/main/java/com/esri/arcgismaps/sample/configurebasemapstyleparameters/components/MapViewModel.kt
@@ -104,6 +104,6 @@ class MapViewModel(application: Application) : AndroidViewModel(application) {
             }
         }
         // set a new basemap with the chosen style parameters
-        map.setBasemap(Basemap(BasemapStyle.OsmLightGray, basemapStyleParameters))
+        map.setBasemap(Basemap(BasemapStyle.ArcGISLightGray, basemapStyleParameters))
     }
 }

--- a/samples/edit-features-using-feature-forms/src/main/java/com/esri/arcgismaps/sample/editfeaturesusingfeatureforms/screens/MainScreen.kt
+++ b/samples/edit-features-using-feature-forms/src/main/java/com/esri/arcgismaps/sample/editfeaturesusingfeatureforms/screens/MainScreen.kt
@@ -62,6 +62,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import com.arcgismaps.toolkit.featureforms.FeatureForm
+import com.arcgismaps.toolkit.featureforms.FeatureFormState
 import com.arcgismaps.toolkit.featureforms.ValidationErrorVisibility
 import com.arcgismaps.toolkit.featureforms.theme.FeatureFormDefaults
 import com.arcgismaps.toolkit.geoviewcompose.MapView
@@ -133,7 +134,7 @@ fun MainScreen(mapViewModel: MapViewModel) {
                     })
                 // display the selected feature form using the Toolkit component
                 FeatureForm(
-                    featureForm = featureForm!!,
+                    featureFormState = FeatureFormState(featureForm!!,scope),
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(top = 20.dp)

--- a/samples/edit-features-using-feature-forms/src/main/java/com/esri/arcgismaps/sample/editfeaturesusingfeatureforms/screens/MainScreen.kt
+++ b/samples/edit-features-using-feature-forms/src/main/java/com/esri/arcgismaps/sample/editfeaturesusingfeatureforms/screens/MainScreen.kt
@@ -134,7 +134,7 @@ fun MainScreen(mapViewModel: MapViewModel) {
                     })
                 // display the selected feature form using the Toolkit component
                 FeatureForm(
-                    featureFormState = FeatureFormState(featureForm!!,scope),
+                    featureFormState = FeatureFormState(featureForm!!, scope),
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(top = 20.dp)


### PR DESCRIPTION
## Description
PR to: 
-  remove `OsmLightGray` from being used in the sample viewer. 
- update `FeatureForm` constructor to use  `featureFormState`. 


[vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/150/