### PR TITLE
SV: bump heap size limits

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.daemon=true
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xms8g -Xmx16g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects


### PR DESCRIPTION
## Description
PR to increase JVM memory allocation for Gradle builds: (Toolkit [jvm limit](https://github.com/Esri/arcgis-maps-sdk-kotlin-toolkit/blob/main/gradle.properties#L27) for reference)
- Initial heap size (-Xms): JVM now starts with a large preallocated heap to reduce resizing overhead during builds.
  - Before: Not explicitly set (default JVM value, usually ~256–512 MB)
  - Now: Set to 8 GB (-Xms8g)
- Maximum heap size (-Xmx): Allow gradle to use more memory, reducing risk of Java heap space errors.
  - Before: 4 GB (-Xmx4096m)
  - Now: 16 GB (-Xmx16g) 

## Links and Data
Sample issue: [#6395](https://devtopia.esri.com/runtime/kotlin/issues/6395)
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/152/
