### PR TITLE
Update to use compileSdk from toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ ArcGIS Maps SDK for Kotlin v200.8.0 samples.  The `main` branch of this reposito
 
 ## Prerequisites
 
-* The samples are building with `compileSdkVersion 35`
+* The samples are building with `compileSdkVersion 36`
 * [Android Studio](http://developer.android.com/sdk/index.html)
 * [An ArcGIS Developers API key](https://developers.arcgis.com/kotlin/get-started/#3-get-an-api-key)
 

--- a/build-logic/convention/src/main/java/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/AndroidApplicationConventionPlugin.kt
@@ -16,7 +16,7 @@ class AndroidApplicationConventionPlugin: Plugin<Project> {
 
             extensions.configure<ApplicationExtension> {
                 configureKotlinAndroid(this)
-                compileSdk = 35
+                compileSdk = libs.findVersion("targetSdk").get().toString().toInt()
                 defaultConfig {
 
                     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/build-logic/convention/src/main/java/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/AndroidLibraryConventionPlugin.kt
@@ -19,7 +19,7 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
 
             extensions.configure<LibraryExtension> {
                 configureKotlinAndroid(this)
-                compileSdk = 35
+                compileSdk = libs.findVersion("targetSdk").get().toString().toInt()
                 defaultConfig {
                     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
                     vectorDrawables {


### PR DESCRIPTION
## Description
PR to update the SV to point to use compile SDK `36` from the toml version. 

## Links and Data
Sample issue: [#6472](https://devtopia.esri.com/runtime/kotlin/issues/6472)
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/156/