### PR TITLE
Address SV build warnings/deprecations

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 # ArcGIS Maps SDK for Kotlin version
-arcgisMapsKotlinVersion = "300.0.0-4698"
+arcgisMapsKotlinVersion = "300.0.0-4719"
 
 ### Android versions
 androidGradlePlugin = "8.12.1"
@@ -19,6 +19,7 @@ roomVersion = "2.7.2"
 kotlinVersion = "2.2.10"
 coreKtx = "1.17.0"
 ksp = "2.2.10-2.0.2"
+kotlinReflection = "2.2.20"
 commonsIoVersion = "2.20.0"
 
 ### Compose versions
@@ -54,6 +55,7 @@ commons-io = { group = "commons-io", name = "commons-io", version.ref = "commons
 android-material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintLayoutVersion" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect" , version.ref = "kotlinReflection"}
 accompanist-systemuicontroller = { module = "com.google.accompanist:accompanist-systemuicontroller", version.ref = "accompanistSystemuicontroller" }
 androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "workVersion" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }

--- a/samples/analyze-hotspots/src/main/res/values/strings.xml
+++ b/samples/analyze-hotspots/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
     <string name="analyze_hotspots_app_name">Analyze hotspots</string>
-    <string name="service_url">http://sampleserver6.arcgisonline.com/arcgis/rest/services/911CallsHotspot/GPServer/911%20Calls%20Hotspot</string>
+    <string name="service_url" formatted="false">http://sampleserver6.arcgisonline.com/arcgis/rest/services/911CallsHotspot/GPServer/911%20Calls%20Hotspot</string>
 </resources>

--- a/samples/analyze-network-with-subnetwork-trace/build.gradle.kts
+++ b/samples/analyze-network-with-subnetwork-trace/build.gradle.kts
@@ -20,4 +20,5 @@ android {
 
 dependencies {
     // Only module specific dependencies needed here
+    implementation(libs.kotlin.reflect)
 }

--- a/samples/analyze-network-with-subnetwork-trace/src/main/java/com/esri/arcgismaps/sample/analyzenetworkwithsubnetworktrace/MainActivity.kt
+++ b/samples/analyze-network-with-subnetwork-trace/src/main/java/com/esri/arcgismaps/sample/analyzenetworkwithsubnetworktrace/MainActivity.kt
@@ -286,9 +286,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
                     valuesEditText.inputType = InputType.TYPE_CLASS_NUMBER
                     setVisible(valuesEditText.id)
                 }
-                else -> {
-                    showError("Unexpected utility network attribute data type.")
-                }
             }
         }
     }
@@ -438,9 +435,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
                     networkAttributeNameAndOperator +
                             (expression.otherNetworkAttribute?.name ?: expression.value)
                 }
-            }
-            else -> {
-                return null
             }
         }
     }

--- a/samples/project-geometry/src/main/res/values/strings.xml
+++ b/samples/project-geometry/src/main/res/values/strings.xml
@@ -2,5 +2,5 @@
     <string name="project_geometry_app_name">Project geometry</string>
     <string name="title_text">Coordinates</string>
     <string name="tap_to_begin">Tap to begin</string>
-    <string name="projection_info_text">Original: %1s\nProjected: %2s</string>
+    <string name="projection_info_text" formatted="false">Original: %1s\nProjected: %2s</string>
 </resources>

--- a/samples/show-callout/src/main/res/values/strings.xml
+++ b/samples/show-callout/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
     <string name="show_callout_app_name">Show callout</string>
-    <string name="callout_text">"Lat: %.4f, Lon: %.4f"</string>
+    <string name="callout_text" formatted="false">"Lat: %.4f, Lon: %.4f"</string>
 </resources>

--- a/samples/show-device-location-using-indoor-positioning/src/main/AndroidManifest.xml
+++ b/samples/show-device-location-using-indoor-positioning/src/main/AndroidManifest.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.esri.arcgismaps.sample.showdevicelocationusingindoorpositioning"
-    xmlns:tools="http://schemas.android.com/tools">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.BLUETOOTH" />
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" tools:remove="android:usesPermissionFlags"/>
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
 
     <application><activity


### PR DESCRIPTION
## Description

PR to inspect and remove deprecated code & fix warnings. Honestly I did not find any current usages of SDK/Toolkit in the samples project but addressed few things to clean up logs. 

Here are the list of warnings addressed: 

- show-device-location-using-indoor-positioning:
  - package="com.esri.arcgismaps.sample.showdevicelocationusingindoorpositioning" found in source AndroidManifest.xml: Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported, and the value is ignored.
  - uses-permission#android.permission.BLUETOOTH_SCAN@android:usesPermissionFlags was tagged at AndroidManifest.xml:10 to remove other declarations but no other declaration present


- show-callout
  - Multiple substitutions specified in non-positional format of string resource string/callout_text. Did you mean to add the formatted="false" attribute?

- project-geometry
  - Multiple substitutions specified in non-positional format of string resource string/projection_info_text. Did you mean to add the formatted="false" attribute?

- analyze-hotspots
  - Multiple substitutions specified in non-positional format of string resource string/service_url. Did you mean to add the formatted="false" attribute?

- analyze-network-with-subnetwork-trace
  -  Call uses reflection API which is not found in compilation classpath. Make sure you have kotlin-reflect.jar in the classpath.
  - when' is exhaustive so 'else' is redundant here.


## Links and Data
Sample issue: [#6259](https://devtopia.esri.com/runtime/kotlin/issues/6259)
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [x] link: [Link](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/157)