### PR TITLE
Snap geometry edits fix

### DIFF
--- a/samples/snap-geometry-edits/src/main/java/com/esri/arcgismaps/sample/snapgeometryedits/components/SnapGeometryEditsViewModel.kt
+++ b/samples/snap-geometry-edits/src/main/java/com/esri/arcgismaps/sample/snapgeometryedits/components/SnapGeometryEditsViewModel.kt
@@ -66,6 +66,7 @@ class SnapGeometryEditsViewModel(
     val snapSourceList: StateFlow<List<SnapSourceSettings>> = _snapSourceSettingsList
 
     // create boolean flags to track the state of UI components
+    val isLayersLoaded = mutableStateOf(false)
     val isCreateButtonEnabled = mutableStateOf(false)
     val isSnapSettingsButtonEnabled = mutableStateOf(false)
     val isBottomSheetVisible = mutableStateOf(false)
@@ -104,7 +105,9 @@ class SnapGeometryEditsViewModel(
                         )
                     }
                 }
+                isLayersLoaded.value = true
             }.onFailure { error ->
+                isLayersLoaded.value = true
                 messageDialogVM.showMessageDialog(
                     error.message.toString(),
                     error.cause.toString()

--- a/samples/snap-geometry-edits/src/main/java/com/esri/arcgismaps/sample/snapgeometryedits/components/SnapGeometryEditsViewModel.kt
+++ b/samples/snap-geometry-edits/src/main/java/com/esri/arcgismaps/sample/snapgeometryedits/components/SnapGeometryEditsViewModel.kt
@@ -66,7 +66,7 @@ class SnapGeometryEditsViewModel(
     val snapSourceList: StateFlow<List<SnapSourceSettings>> = _snapSourceSettingsList
 
     // create boolean flags to track the state of UI components
-    val isLayersLoaded = mutableStateOf(false)
+    val areLayersLoading = mutableStateOf(true)
     val isCreateButtonEnabled = mutableStateOf(false)
     val isSnapSettingsButtonEnabled = mutableStateOf(false)
     val isBottomSheetVisible = mutableStateOf(false)
@@ -105,9 +105,9 @@ class SnapGeometryEditsViewModel(
                         )
                     }
                 }
-                isLayersLoaded.value = true
+                areLayersLoading.value = false
             }.onFailure { error ->
-                isLayersLoaded.value = true
+                areLayersLoading.value = false
                 messageDialogVM.showMessageDialog(
                     error.message.toString(),
                     error.cause.toString()

--- a/samples/snap-geometry-edits/src/main/java/com/esri/arcgismaps/sample/snapgeometryedits/screens/SnapGeometryEditsScreen.kt
+++ b/samples/snap-geometry-edits/src/main/java/com/esri/arcgismaps/sample/snapgeometryedits/screens/SnapGeometryEditsScreen.kt
@@ -103,7 +103,7 @@ fun MainScreen(sampleName: String) {
                 ) { mapViewModel.dismissBottomSheet() }
             }
         }
-        if (!mapViewModel.isLayersLoaded.value) {
+        if (mapViewModel.areLayersLoading.value) {
             LoadingDialog("Loading map with feature layers...")
         }
     })

--- a/samples/snap-geometry-edits/src/main/java/com/esri/arcgismaps/sample/snapgeometryedits/screens/SnapGeometryEditsScreen.kt
+++ b/samples/snap-geometry-edits/src/main/java/com/esri/arcgismaps/sample/snapgeometryedits/screens/SnapGeometryEditsScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier

--- a/samples/snap-geometry-edits/src/main/java/com/esri/arcgismaps/sample/snapgeometryedits/screens/SnapGeometryEditsScreen.kt
+++ b/samples/snap-geometry-edits/src/main/java/com/esri/arcgismaps/sample/snapgeometryedits/screens/SnapGeometryEditsScreen.kt
@@ -26,11 +26,13 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import com.arcgismaps.toolkit.geoviewcompose.MapView
+import com.esri.arcgismaps.sample.sampleslib.components.LoadingDialog
 import com.esri.arcgismaps.sample.sampleslib.components.MessageDialog
 import com.esri.arcgismaps.sample.sampleslib.components.SampleTopAppBar
 import com.esri.arcgismaps.sample.snapgeometryedits.components.SnapGeometryEditsViewModel
@@ -101,6 +103,9 @@ fun MainScreen(sampleName: String) {
                     isSnapSourceEnabled = mapViewModel.snapSourceCheckedState
                 ) { mapViewModel.dismissBottomSheet() }
             }
+        }
+        if (!mapViewModel.isLayersLoaded.value) {
+            LoadingDialog("Loading map with feature layers...")
         }
     })
 }


### PR DESCRIPTION
## Description
PR to patch `Snap geometry edits` sample to block UI when feature layers are loading to populate the bottom sheet. 

## Links and Data
Sample issue: `kotlin/issues/6251`
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [x] link: [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/200/)
