### PR TITLE
Bump heap space

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.daemon=true
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xms8g -Xmx16g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects


### PR DESCRIPTION
## Description

PR to address `Java heap space OutOfMemoryError` build failure on `200.8.1.4749`. (Compare with [v.next](https://github.com/Esri/arcgis-maps-sdk-kotlin-samples/blob/v.next/gradle.properties#L11))


## Links and Data
Sample issue: `kotlin/issues/7028`
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [x] link: [vTest](https://runtime-kotlin.esri.com/view/vTest/job/vtest/job/sampleviewer/211)

