### PR TITLE
reorder parameters to match canonical ordering

### DIFF
--- a/samples/add-building-scene-layer/src/main/java/com/esri/arcgismaps/sample/addbuildingscenelayer/screens/AddBuildingSceneLayerScreen.kt
+++ b/samples/add-building-scene-layer/src/main/java/com/esri/arcgismaps/sample/addbuildingscenelayer/screens/AddBuildingSceneLayerScreen.kt
@@ -84,8 +84,8 @@ fun AddBuildingSceneLayerScreen(sampleName: String) {
 
     val arcGISScene = remember {
         ArcGISScene(
-            basemapStyle = BasemapStyle.ArcGISTopographic,
-            viewingMode = SceneViewingMode.Local
+            viewingMode = SceneViewingMode.Local,
+            basemapStyle = BasemapStyle.ArcGISTopographic
         ).apply {
             baseSurface.elevationSources.add(elevationSource)
             operationalLayers.add(buildingSceneLayer)

--- a/samples/display-local-scene/src/main/java/com/esri/arcgismaps/sample/displaylocalscene/screens/DisplayLocalSceneScreen.kt
+++ b/samples/display-local-scene/src/main/java/com/esri/arcgismaps/sample/displaylocalscene/screens/DisplayLocalSceneScreen.kt
@@ -59,8 +59,8 @@ fun DisplayLocalSceneScreen(sampleName: String) {
 
                 val arcGISScene = remember {
                     ArcGISScene(
-                        BasemapStyle.ArcGISTopographic,
-                        SceneViewingMode.Local
+                        viewingMode = SceneViewingMode.Local,
+                        basemapStyle = BasemapStyle.ArcGISTopographic
                     ).apply {
                         operationalLayers.add(sceneLayer)
                         baseSurface.elevationSources.add(elevationSource)


### PR DESCRIPTION
name the parameters to ArcGISScene constructor calls in BSL samples to avoid incident when the parameter order is changed (upcoming change). Also, change the order to match the upcoming canonical ordering.

issue: https://devtopia.esri.com/runtime/runtimecore/pull/35395

announcement: https://esri-runtime.slack.com/archives/C0YV42B39/p1770056139693179

- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/vTest/job/vtest/job/sampleviewer/242/
-->

