### PR TITLE
Use modelName instead of name

### DIFF
--- a/samples/add-building-scene-layer/src/main/java/com/esri/arcgismaps/sample/addbuildingscenelayer/screens/AddBuildingSceneLayerScreen.kt
+++ b/samples/add-building-scene-layer/src/main/java/com/esri/arcgismaps/sample/addbuildingscenelayer/screens/AddBuildingSceneLayerScreen.kt
@@ -116,8 +116,8 @@ fun AddBuildingSceneLayerScreen(sampleName: String) {
     LaunchedEffect(Unit) {
         buildingSceneLayer.load().onSuccess {
             val sublayers = buildingSceneLayer.sublayers
-            overviewSublayer = sublayers.first { it.name == "Overview" }
-            fullModelSublayer = sublayers.first { it.name == "Full Model" }
+            overviewSublayer = sublayers.first { it.modelName == "Overview" }
+            fullModelSublayer = sublayers.first { it.modelName == "FullModel" }
         }
     }
 

--- a/samples/filter-building-scene-layer/src/main/java/com/esri/arcgismaps/sample/filterbuildingscenelayer/components/FilterBuildingSceneLayerViewModel.kt
+++ b/samples/filter-building-scene-layer/src/main/java/com/esri/arcgismaps/sample/filterbuildingscenelayer/components/FilterBuildingSceneLayerViewModel.kt
@@ -89,7 +89,7 @@ class FilterBuildingSceneLayerViewModel(app: Application) : AndroidViewModel(app
 
                         // The top-level sublayer groups will be the categories
                         buildingSceneLayer.sublayers.find { sublayer ->
-                            sublayer.name == "Full Model"
+                            sublayer.modelName == "FullModel"
                         }?.let { buildingSublayer ->
                             buildingSublayer as BuildingGroupSublayer
                             categories.addAll(buildingSublayer.sublayers.sortedBy { it.name })


### PR DESCRIPTION
## Description
>Through some research, it was found that the names for the main sublayers of Building Scene Layers, the name field "Overview" and "Full Model", are not always in English. It would be more universally applicable to utilize the fullModel field which is always in English.

Changes uses of `name` to use `modelName` (I think it is a mistype above when it says "fullModel" field. 

## Links and Data
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/252/console

Screen shots of the samples after the change

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/b3d02074-0b40-4dc1-a04b-505fb174ae47" />
<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/17ed8581-1f20-4239-aeb4-97a76514f5ec" />
