### PR TITLE
Refine `FeatureForm` sample

### DIFF
--- a/samples/edit-features-using-feature-forms/README.md
+++ b/samples/edit-features-using-feature-forms/README.md
@@ -18,9 +18,9 @@ Tap a feature on the map to open a sheet displaying the feature form. Select for
 2. When the map is tapped, perform an identify operation to check if the tapped location is an `ArcGISFeature`.
 3. Create a `FeatureForm` object using the identified `ArcGISFeature`.
 * **Note:** If the feature's `FeatureLayer`, `ArcGISFeatureTable`, or the `SubtypeSublayer` has an authored `FeatureFormDefinition`, then this definition will be used to create the `FeatureForm`. If such a definition is not found, a default definition is generated.
-4. Use the `FeatureForm` toolkit component to display the feature form configuration by providing the created `featureForm` object.
+4. Use the `FeatureForm` toolkit component to display the feature form configuration by providing a `FeatureFormState` created using the `featureForm` object.
 5. Optionally, you can add a `validationErrorVisibility` option to the `FeatureForm` toolkit component that determines the visibility of validation errors.
-6. Once edits are added to the form fields, check if the validation errors list are empty using `featureForm.validationErrors` to verify that there are no errors.
+6. Listen to the `onEditingEvent` callback to track when edits are saved on the form.
 7. To commit edits on the service geodatabase:
    1. Call `featureForm.finishEditing()` to save edits to the database.
    2. Retrieve the backing service feature table's geodatabase using `serviceFeatureTable?.serviceGeodatabase`.

--- a/samples/edit-features-using-feature-forms/README.md
+++ b/samples/edit-features-using-feature-forms/README.md
@@ -22,11 +22,10 @@ Tap a feature on the map to open a sheet displaying the feature form. Select for
 5. Optionally, you can add a `validationErrorVisibility` option to the `FeatureForm` toolkit component that determines the visibility of validation errors.
 6. Listen to the `onEditingEvent` callback to track when edits are saved on the form.
 7. To commit edits on the service geodatabase:
-   1. Call `featureForm.finishEditing()` to save edits to the database.
-   2. Retrieve the backing service feature table's geodatabase using `serviceFeatureTable?.serviceGeodatabase`.
-   3. Verify the service geodatabase can commit changes back to the service using `serviceGeodatabase.serviceInfo?.canUseServiceGeodatabaseApplyEdits`
-   4. If apply edits are allowed, call `serviceGeodatabase.applyEdits()` to apply local edits to the online service.
-   5. If edits are not allowed on the `ServiceGeodatabase`, then apply edits to the `ServiceFeatureTable` using `ServiceFeatureTable.applyEdits()`
+   1. Retrieve the backing service feature table's geodatabase using `serviceFeatureTable?.serviceGeodatabase`.
+   2. Verify the service geodatabase can commit changes back to the service using `serviceGeodatabase.serviceInfo?.canUseServiceGeodatabaseApplyEdits`
+   3. If apply edits are allowed, call `serviceGeodatabase.applyEdits()` to apply local edits to the online service.
+   4. If edits are not allowed on the `ServiceGeodatabase`, then apply edits to the `ServiceFeatureTable` using `ServiceFeatureTable.applyEdits()`
 
 ## Relevant API
 

--- a/samples/edit-features-using-feature-forms/src/main/java/com/esri/arcgismaps/sample/editfeaturesusingfeatureforms/components/MapViewModel.kt
+++ b/samples/edit-features-using-feature-forms/src/main/java/com/esri/arcgismaps/sample/editfeaturesusingfeatureforms/components/MapViewModel.kt
@@ -78,38 +78,31 @@ class MapViewModel(application: Application) : AndroidViewModel(application) {
 
         viewModelScope.launch {
             // commits changes of the edited feature to the database
-            featureForm.finishEditing().onSuccess {
-                serviceFeatureTable.serviceGeodatabase?.let { database ->
-                    if (database.serviceInfo?.canUseServiceGeodatabaseApplyEdits == true) {
-                        // applies all local edits in the tables to the service
-                        database.applyEdits().onFailure {
-                            return@onFailure messageDialogVM.showMessageDialog(
-                                title = it.message.toString(),
-                                description = it.cause.toString()
-                            )
-                        }
-                    } else {
-                        // uploads any changes to the local table to the feature service
-                        serviceFeatureTable.applyEdits().onFailure {
-                            return@onFailure messageDialogVM.showMessageDialog(
-                                title = it.message.toString(),
-                                description = it.cause.toString()
-                            )
-                        }
+            serviceFeatureTable.serviceGeodatabase?.let { database ->
+                if (database.serviceInfo?.canUseServiceGeodatabaseApplyEdits == true) {
+                    // applies all local edits in the tables to the service
+                    database.applyEdits().onFailure {
+                        return@onFailure messageDialogVM.showMessageDialog(
+                            title = it.message.toString(),
+                            description = it.cause.toString()
+                        )
+                    }
+                } else {
+                    // uploads any changes to the local table to the feature service
+                    serviceFeatureTable.applyEdits().onFailure {
+                        return@onFailure messageDialogVM.showMessageDialog(
+                            title = it.message.toString(),
+                            description = it.cause.toString()
+                        )
                     }
                 }
-                // resets the attributes and geometry to the values in the data source
-                featureForm.feature.refresh()
-                // unselect the feature after the edits have been saved
-                (featureForm.feature.featureTable?.layer as FeatureLayer).clearSelection()
-                // dismiss dialog when edits are completed
-                onEditsCompleted()
-            }.onFailure {
-                return@onFailure messageDialogVM.showMessageDialog(
-                    title = it.message.toString(),
-                    description = it.cause.toString()
-                )
             }
+            // resets the attributes and geometry to the values in the data source
+            featureForm.feature.refresh()
+            // unselect the feature after the edits have been saved
+            (featureForm.feature.featureTable?.layer as FeatureLayer).clearSelection()
+            // dismiss dialog when edits are completed
+            onEditsCompleted()
         }
     }
 

--- a/samples/edit-features-using-feature-forms/src/main/java/com/esri/arcgismaps/sample/editfeaturesusingfeatureforms/components/MapViewModel.kt
+++ b/samples/edit-features-using-feature-forms/src/main/java/com/esri/arcgismaps/sample/editfeaturesusingfeatureforms/components/MapViewModel.kt
@@ -27,9 +27,6 @@ import com.arcgismaps.mapping.ArcGISMap
 import com.arcgismaps.mapping.PortalItem
 import com.arcgismaps.mapping.featureforms.FeatureForm
 import com.arcgismaps.mapping.featureforms.FeatureFormDefinition
-import com.arcgismaps.mapping.featureforms.FieldFormElement
-import com.arcgismaps.mapping.featureforms.FormElement
-import com.arcgismaps.mapping.featureforms.GroupFormElement
 import com.arcgismaps.mapping.layers.FeatureLayer
 import com.arcgismaps.mapping.view.SingleTapConfirmedEvent
 import com.arcgismaps.toolkit.featureforms.FeatureFormState
@@ -160,32 +157,6 @@ class MapViewModel(application: Application) : AndroidViewModel(application) {
                     )
                 }
             }
-        }
-    }
-}
-
-/**
- * Returns the [FieldFormElement] with the given [fieldName] in the [FeatureForm]. If none exists
- * null is returned.
- */
-fun List<FormElement>.getFormElement(fieldName: String): FieldFormElement? {
-    val fieldElements = filterIsInstance<FieldFormElement>()
-    val element = if (fieldElements.isNotEmpty()) {
-        fieldElements.firstNotNullOfOrNull {
-            if (it.fieldName == fieldName) it else null
-        }
-    } else {
-        null
-    }
-
-    return element ?: run {
-        val groupElements = filterIsInstance<GroupFormElement>()
-        if (groupElements.isNotEmpty()) {
-            groupElements.firstNotNullOfOrNull {
-                it.elements.getFormElement(fieldName)
-            }
-        } else {
-            null
         }
     }
 }

--- a/samples/edit-features-using-feature-forms/src/main/java/com/esri/arcgismaps/sample/editfeaturesusingfeatureforms/components/MapViewModel.kt
+++ b/samples/edit-features-using-feature-forms/src/main/java/com/esri/arcgismaps/sample/editfeaturesusingfeatureforms/components/MapViewModel.kt
@@ -23,7 +23,6 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.arcgismaps.data.ArcGISFeature
 import com.arcgismaps.data.ServiceFeatureTable
-import com.arcgismaps.exceptions.FeatureFormValidationException
 import com.arcgismaps.mapping.ArcGISMap
 import com.arcgismaps.mapping.PortalItem
 import com.arcgismaps.mapping.featureforms.FeatureForm
@@ -37,9 +36,6 @@ import com.arcgismaps.toolkit.featureforms.FeatureFormState
 import com.arcgismaps.toolkit.geoviewcompose.MapViewProxy
 import com.esri.arcgismaps.sample.editfeaturesusingfeatureforms.R
 import com.esri.arcgismaps.sample.sampleslib.components.MessageDialogViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 /**
@@ -58,10 +54,6 @@ class MapViewModel(application: Application) : AndroidViewModel(application) {
     private val _featureFormState = mutableStateOf<FeatureFormState?>(null)
     val featureFormState: FeatureFormState?
         get() = _featureFormState.value
-
-    // keep track of the list of validation errors
-    private val _errors = MutableStateFlow<List<ErrorInfo>>(listOf())
-    val errors: StateFlow<List<ErrorInfo>> = _errors.asStateFlow()
 
     // create a ViewModel to handle dialog interactions
     val messageDialogVM: MessageDialogViewModel = MessageDialogViewModel()
@@ -84,83 +76,44 @@ class MapViewModel(application: Application) : AndroidViewModel(application) {
         val featureForm = featureFormState?.activeFeatureForm
             ?: return messageDialogVM.showMessageDialog("Feature form state is not configured")
 
-        // update the state flow with the list of validation errors found
-        _errors.value = validateFormInputEdits(featureForm)
-        // if there are no errors then update the feature
-        if (_errors.value.isEmpty()) {
-            val serviceFeatureTable = featureForm.feature.featureTable as? ServiceFeatureTable
-                ?: return messageDialogVM.showMessageDialog("Cannot save feature edit without a ServiceFeatureTable")
+        val serviceFeatureTable = featureForm.feature.featureTable as? ServiceFeatureTable
+            ?: return messageDialogVM.showMessageDialog("Cannot save feature edit without a ServiceFeatureTable")
 
-            viewModelScope.launch {
-                // commits changes of the edited feature to the database
-                featureForm.finishEditing().onSuccess {
-                    serviceFeatureTable.serviceGeodatabase?.let { database ->
-                        if (database.serviceInfo?.canUseServiceGeodatabaseApplyEdits == true) {
-                            // applies all local edits in the tables to the service
-                            database.applyEdits().onFailure {
-                                return@onFailure messageDialogVM.showMessageDialog(
-                                    title = it.message.toString(),
-                                    description = it.cause.toString()
-                                )
-                            }
-                        } else {
-                            // uploads any changes to the local table to the feature service
-                            serviceFeatureTable.applyEdits().onFailure {
-                                return@onFailure messageDialogVM.showMessageDialog(
-                                    title = it.message.toString(),
-                                    description = it.cause.toString()
-                                )
-                            }
+        viewModelScope.launch {
+            // commits changes of the edited feature to the database
+            featureForm.finishEditing().onSuccess {
+                serviceFeatureTable.serviceGeodatabase?.let { database ->
+                    if (database.serviceInfo?.canUseServiceGeodatabaseApplyEdits == true) {
+                        // applies all local edits in the tables to the service
+                        database.applyEdits().onFailure {
+                            return@onFailure messageDialogVM.showMessageDialog(
+                                title = it.message.toString(),
+                                description = it.cause.toString()
+                            )
+                        }
+                    } else {
+                        // uploads any changes to the local table to the feature service
+                        serviceFeatureTable.applyEdits().onFailure {
+                            return@onFailure messageDialogVM.showMessageDialog(
+                                title = it.message.toString(),
+                                description = it.cause.toString()
+                            )
                         }
                     }
-                    // resets the attributes and geometry to the values in the data source
-                    featureForm.feature.refresh()
-                    // unselect the feature after the edits have been saved
-                    (featureForm.feature.featureTable?.layer as FeatureLayer).clearSelection()
-                    // dismiss dialog when edits are completed
-                    onEditsCompleted()
-                }.onFailure {
-                    return@onFailure messageDialogVM.showMessageDialog(
-                        title = it.message.toString(),
-                        description = it.cause.toString()
-                    )
                 }
+                // resets the attributes and geometry to the values in the data source
+                featureForm.feature.refresh()
+                // unselect the feature after the edits have been saved
+                (featureForm.feature.featureTable?.layer as FeatureLayer).clearSelection()
+                // dismiss dialog when edits are completed
+                onEditsCompleted()
+            }.onFailure {
+                return@onFailure messageDialogVM.showMessageDialog(
+                    title = it.message.toString(),
+                    description = it.cause.toString()
+                )
             }
         }
-    }
-
-    /**
-     * Performs validation checks on the given [featureForm] with local edits.
-     * Return a list of [ErrorInfo] if errors are found, if not, empty list is returned.
-     */
-    private fun validateFormInputEdits(featureForm: FeatureForm): List<ErrorInfo> {
-        val errors = mutableListOf<ErrorInfo>()
-        // If an element is editable or derives its value from an arcade expression,
-        // its errors must be corrected before submitting the form
-        featureForm.validationErrors.value.forEach { entry ->
-            entry.value.forEach { error ->
-                featureForm.elements.getFormElement(entry.key)?.let { formElement ->
-                    // Ignore validation on non-editable and non-visible elements
-                    if (formElement.isEditable.value || formElement.hasValueExpression) {
-                        errors.add(
-                            ErrorInfo(
-                                fieldName = formElement.label,
-                                error = error as FeatureFormValidationException
-                            )
-                        )
-                    }
-                }
-            }
-        }
-        return errors
-    }
-
-    /**
-     * Cancels the commit by resetting the validation errors.
-     */
-    fun cancelCommit() {
-        // reset the validation errors
-        _errors.value = listOf()
     }
 
     /**
@@ -170,15 +123,6 @@ class MapViewModel(application: Application) : AndroidViewModel(application) {
         val featureForm = featureFormState?.activeFeatureForm
         (featureForm?.feature?.featureTable?.layer as FeatureLayer).clearSelection()
         _featureFormState.value = null
-    }
-
-    /**
-     * Discard edits and unselects feature from the layer
-     */
-    suspend fun rollbackEdits() {
-        featureFormState?.discardEdits()
-        // reset the validation errors
-        _errors.value = listOf()
     }
 
     /**
@@ -245,8 +189,3 @@ fun List<FormElement>.getFormElement(fieldName: String): FieldFormElement? {
         }
     }
 }
-
-/**
- * Class that provides a validation error [error] for the field with name [fieldName].
- */
-data class ErrorInfo(val fieldName: String, val error: FeatureFormValidationException)

--- a/samples/edit-features-using-feature-forms/src/main/java/com/esri/arcgismaps/sample/editfeaturesusingfeatureforms/screens/MainScreen.kt
+++ b/samples/edit-features-using-feature-forms/src/main/java/com/esri/arcgismaps/sample/editfeaturesusingfeatureforms/screens/MainScreen.kt
@@ -176,6 +176,7 @@ fun MainScreen(mapViewModel: MapViewModel) {
                 scope.launch {
                     featureFormState?.discardEdits()
                     sheetState.hide()
+                    mapViewModel.clearSelection()
                     showDiscardEditsDialog = false
                 }
             },

--- a/samples/edit-features-using-feature-forms/src/main/java/com/esri/arcgismaps/sample/editfeaturesusingfeatureforms/screens/MainScreen.kt
+++ b/samples/edit-features-using-feature-forms/src/main/java/com/esri/arcgismaps/sample/editfeaturesusingfeatureforms/screens/MainScreen.kt
@@ -19,16 +19,12 @@ package com.esri.arcgismaps.sample.editfeaturesusingfeatureforms.screens
 import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -42,7 +38,6 @@ import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -51,7 +46,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -62,7 +56,6 @@ import com.arcgismaps.toolkit.featureforms.ValidationErrorVisibility
 import com.arcgismaps.toolkit.featureforms.theme.FeatureFormDefaults
 import com.arcgismaps.toolkit.geoviewcompose.MapView
 import com.esri.arcgismaps.sample.editfeaturesusingfeatureforms.R
-import com.esri.arcgismaps.sample.editfeaturesusingfeatureforms.components.ErrorInfo
 import com.esri.arcgismaps.sample.editfeaturesusingfeatureforms.components.MapViewModel
 import com.esri.arcgismaps.sample.sampleslib.components.MessageDialog
 import com.esri.arcgismaps.sample.sampleslib.components.SampleTopAppBar
@@ -76,9 +69,6 @@ fun MainScreen(mapViewModel: MapViewModel) {
     val scope = rememberCoroutineScope()
     // the feature form the currently selected feature
     val featureFormState = mapViewModel.featureFormState
-
-    // the validation errors found when the edits are applied
-    val formValidationErrors by mapViewModel.errors.collectAsState()
 
     // boolean trackers for save and discard edits dialogs
     var showSaveEditsDialog by remember { mutableStateOf(false) }
@@ -152,12 +142,7 @@ fun MainScreen(mapViewModel: MapViewModel) {
                                 }
                             }
 
-                            is FeatureFormEditingEvent.DiscardedEdits -> {
-                                // when the discard edits event is received, roll back any edits
-                                scope.launch {
-                                    mapViewModel.rollbackEdits()
-                                }
-                            }
+                            else -> {}
                         }
                     },
                     colorScheme = FeatureFormDefaults.colorScheme(
@@ -180,13 +165,7 @@ fun MainScreen(mapViewModel: MapViewModel) {
         }
     }
 
-    if (showSaveEditsDialog && formValidationErrors.isNotEmpty()) {
-        // validation errors found, cancel the commit and show validation errors
-        ValidationErrorsDialog(errors = formValidationErrors) {
-            showSaveEditsDialog = false
-            mapViewModel.cancelCommit()
-        }
-    } else if (showSaveEditsDialog) {
+    if (showSaveEditsDialog) {
         // no validation errors found, show dialog when committing edits
         SaveFormDialog()
     }
@@ -195,7 +174,7 @@ fun MainScreen(mapViewModel: MapViewModel) {
         DiscardEditsDialog(
             onConfirm = {
                 scope.launch {
-                    mapViewModel.rollbackEdits()
+                    featureFormState?.discardEdits()
                     sheetState.hide()
                     showDiscardEditsDialog = false
                 }
@@ -259,54 +238,6 @@ private fun SaveFormDialog() {
     }
 }
 
-@Composable
-private fun ValidationErrorsDialog(errors: List<ErrorInfo>, onDismissRequest: () -> Unit) {
-    // show all the validation errors in a dialog
-    AlertDialog(
-        onDismissRequest = onDismissRequest,
-        modifier = Modifier.heightIn(max = 600.dp),
-        confirmButton = {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.Center
-            ) {
-                Button(onClick = onDismissRequest) {
-                    Text(text = stringResource(R.string.view))
-                }
-            }
-        },
-        title = {
-            Column {
-                Text(
-                    modifier = Modifier.fillMaxWidth(),
-                    text = "Form Validation Errors",
-                    style = MaterialTheme.typography.titleLarge,
-                    textAlign = TextAlign.Center
-                )
-            }
-        },
-        text = {
-            Card(modifier = Modifier.fillMaxWidth()) {
-                Column(modifier = Modifier.padding(15.dp)) {
-                    Text(
-                        text = stringResource(R.string.attributes_failed, errors.count()),
-                        color = MaterialTheme.colorScheme.error
-                    )
-                    Spacer(modifier = Modifier.height(10.dp))
-                    LazyColumn(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-                        items(errors.count()) { index ->
-                            Text(
-                                text = "${errors[index].fieldName}: ${errors[index].error::class.simpleName.toString()}",
-                                color = MaterialTheme.colorScheme.error
-                            )
-                        }
-                    }
-                }
-            }
-        }
-    )
-}
-
 /**
  * Extension function to check if there are unsaved edits in the feature form.
  */
@@ -319,13 +250,6 @@ private fun FeatureFormState.hasEdits(): Boolean {
 @Composable
 fun SavePreview() {
     SampleAppTheme { SaveFormDialog() }
-}
-
-@Preview(showBackground = true)
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
-@Composable
-fun ValidationErrorsPreview() {
-    SampleAppTheme { ValidationErrorsDialog(listOf()) { } }
 }
 
 @Preview(showBackground = true)


### PR DESCRIPTION
## Description
<!--
PR to add a new Kotlin sample _"SAMPLE_NAME"_ in `SAMPLE_CATEGORY` category.
-->

I missed a few things in this previous [PR](https://github.com/Esri/arcgis-maps-sdk-kotlin-samples/pull/468) related to the "edit features using feature forms" sample.

- The `FeatureForm` toolkit component now takes care of saving and discarding edits in the form, so the sample does not have to do any additional work. This includes calling `FeatureForm.finishEditing()`. The unneeded code has been removed.
- Similarly, validation errors, if any, are displayed by the toolkit component. Hence the sample does not need to do any additional work. The unneeded code has been removed.
- This simplifies the sample code quite a bit.
- Update the README to reflect this new refined behavior.

## Links and Data

- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/256/
 
## What To Review
<!--
-  Review the code to make sure it is easy to follow like other samples on Android
- `README.md` and `README.metadata.json` files
-->

## How to Test
<!--
Run the sample on the sample viewer or the repo.
-->

<!-- OPTIONAL
## To Discuss
-->

<!-- OPTIONAL
## Screenshots
-->
