### PR TITLE
Create a new camera controller on each configuration change

### DIFF
--- a/samples/show-exploratory-viewshed-from-point-in-scene/src/main/java/com/esri/arcgismaps/sample/showexploratoryviewshedfrompointinscene/components/SceneViewModel.kt
+++ b/samples/show-exploratory-viewshed-from-point-in-scene/src/main/java/com/esri/arcgismaps/sample/showexploratoryviewshedfrompointinscene/components/SceneViewModel.kt
@@ -31,7 +31,6 @@ import com.arcgismaps.mapping.Viewpoint
 import com.arcgismaps.mapping.layers.ArcGISSceneLayer
 import com.arcgismaps.mapping.view.AnalysisOverlay
 import com.arcgismaps.mapping.view.Camera
-import com.arcgismaps.mapping.view.OrbitLocationCameraController
 import com.esri.arcgismaps.sample.showexploratoryviewshedfrompointinscene.R
 
 class SceneViewModel(private val application: Application) : AndroidViewModel(application) {
@@ -45,7 +44,7 @@ class SceneViewModel(private val application: Application) : AndroidViewModel(ap
     private val initMinDistance = 0.0
     private val initMaxDistance = 1500.0
 
-    private val initLocation = Point(
+    val initLocation = Point(
         x = -4.50,
         y = 48.4,
         z = 1000.0
@@ -56,10 +55,6 @@ class SceneViewModel(private val application: Application) : AndroidViewModel(ap
         heading = 0.0,
         pitch = 55.0,
         roll = 0.0
-    )
-    val cameraController = OrbitLocationCameraController(
-        targetPoint = initLocation,
-        distance = 5000.0
     )
     var scene by mutableStateOf(ArcGISScene(BasemapStyle.ArcGISNavigationNight))
     var analysisOverlay by mutableStateOf(AnalysisOverlay())

--- a/samples/show-exploratory-viewshed-from-point-in-scene/src/main/java/com/esri/arcgismaps/sample/showexploratoryviewshedfrompointinscene/screens/MainScreen.kt
+++ b/samples/show-exploratory-viewshed-from-point-in-scene/src/main/java/com/esri/arcgismaps/sample/showexploratoryviewshedfrompointinscene/screens/MainScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.arcgismaps.mapping.view.OrbitLocationCameraController
 import com.arcgismaps.toolkit.geoviewcompose.SceneView
 import com.esri.arcgismaps.sample.sampleslib.components.BottomSheet
 import com.esri.arcgismaps.sample.sampleslib.components.SampleTopAppBar
@@ -64,6 +65,13 @@ fun MainScreen(sampleName: String) {
                         .fillMaxSize()
                         .padding(it)
                 ) {
+
+                    val cameraController = remember {
+                        OrbitLocationCameraController(
+                            targetPoint = sceneViewModel.initLocation,
+                            distance = 5000.0
+                        )
+                    }
                     // composable function that wraps the SceneView
                     SceneView(
                         modifier = Modifier
@@ -71,7 +79,7 @@ fun MainScreen(sampleName: String) {
                             .weight(1f),
                         arcGISScene = sceneViewModel.scene,
                         onDown = { isBottomSheetVisible = false },
-                        cameraController = sceneViewModel.cameraController,
+                        cameraController = cameraController,
                         analysisOverlays = listOf(sceneViewModel.analysisOverlay)
                     )
                 }


### PR DESCRIPTION
## Description
<!--
PR to add a new Kotlin sample _"SAMPLE_NAME"_ in `SAMPLE_CATEGORY` category.
-->

Fixes a crash caused by `ObjectAlreadyOwnedException` in sample "Show exploratory viewshed from point in scene" by moving the camera controller out of the view model and declaring it in compose code. This means that a new camera controller is created on every configuraiton change, which means that the "object already owned" issues can be avoided.

https://devtopia.esri.com/runtime/kotlin/issues/7583

## Links and Data


- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [ ] link: https://runtime-kotlin.esri.com/view/Release/job/300.0.0/job/vtest/job/sampleviewer/3/

## What To Review
<!--
-  Review the code to make sure it is easy to follow like other samples on Android
- `README.md` and `README.metadata.json` files
-->

## How to Test
<!--
Run the sample on the sample viewer or the repo.
-->

<!-- OPTIONAL
## To Discuss
-->

<!-- OPTIONAL
## Screenshots
-->
