### PR TITLE
Target Android API 37

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
         android:roundIcon="@mipmap/arcgis_sdk"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
-        tools:targetApi="36">
+        tools:targetApi="37">
         <activity
             android:name=".SampleViewerLauncherActivity"
             android:exported="true">

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,7 +44,7 @@ coroutinesTest = "1.10.2"
 versionCode = "3001000"
 versionName = "300.1.0"
 minSdk = "28"
-targetSdk = "36"
+targetSdk = "37"
 
 ### Third party libraries
 arcore = "1.54.0"


### PR DESCRIPTION
## Description

Bump compileSdk version to Android 37

## Links and Data

Sample issue: `runtime/kotlin/issues/7860`
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/vTest/job/vtest/job/sampleviewer/273