### PR TITLE
SV: Isolate build config

### DIFF
--- a/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/model/Sample.kt
+++ b/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/model/Sample.kt
@@ -20,7 +20,6 @@ import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
 import android.content.Intent
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.toolkit.authentication.AuthenticatorState
 import kotlinx.serialization.Serializable
 
@@ -130,7 +129,6 @@ data class Sample(
 suspend fun Sample.start(context: Context) {
     // Revoke previously configured ArcGISEnvironment settings like ApiKeys/OAuth tokens/Credentials
     AuthenticatorState().signOut()
-    ArcGISEnvironment.apiKey = null
     // Obtain and launch the sample activity
     val className = Class.forName(mainActivity) as Class<*>
     val sampleLauncherActivity = context.getActivityOrNull() ?: return

--- a/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/model/Sample.kt
+++ b/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/model/Sample.kt
@@ -20,7 +20,10 @@ import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
 import android.content.Intent
+import com.arcgismaps.ApiKey
+import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.toolkit.authentication.AuthenticatorState
+import com.esri.arcgismaps.kotlin.sampleviewer.BuildConfig
 import kotlinx.serialization.Serializable
 
 /**
@@ -127,8 +130,13 @@ data class Sample(
  * Starts the sample activity.
  */
 suspend fun Sample.start(context: Context) {
-    // Revoke previously configured ArcGISEnvironment settings like ApiKeys/OAuth tokens/Credentials
+    // Revoke previously configured ArcGISEnvironment settings OAuth tokens/Credentials
     AuthenticatorState().signOut()
+
+    // Authentication with an API key or named user is
+    // required to access basemaps and other location services
+    ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
+
     // Obtain and launch the sample activity
     val className = Class.forName(mainActivity) as Class<*>
     val sampleLauncherActivity = context.getActivityOrNull() ?: return

--- a/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/ui/screens/home/HomeCategoryScreen.kt
+++ b/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/ui/screens/home/HomeCategoryScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.times
+import com.esri.arcgismaps.kotlin.sampleviewer.BuildConfig
 import com.esri.arcgismaps.kotlin.sampleviewer.R
 import com.esri.arcgismaps.kotlin.sampleviewer.model.Category
 import com.esri.arcgismaps.kotlin.sampleviewer.model.SampleCategory
@@ -133,7 +134,9 @@ fun HomeCategoryScreen(
  */
 @Composable
 fun CheckAccessToken() {
-    var isDialogDisplayed by remember { mutableStateOf(false) }
+    var isDialogDisplayed by remember {
+        mutableStateOf(BuildConfig.ACCESS_TOKEN == "DEFAULT_ACCESS_TOKEN")
+    }
     if (isDialogDisplayed) {
         MessageDialog(
             title = "Access token",

--- a/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/ui/screens/home/HomeCategoryScreen.kt
+++ b/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/ui/screens/home/HomeCategoryScreen.kt
@@ -63,7 +63,6 @@ import com.esri.arcgismaps.kotlin.sampleviewer.model.SampleCategory
 import com.esri.arcgismaps.kotlin.sampleviewer.ui.components.CategoryCard
 import com.esri.arcgismaps.sample.sampleslib.components.MessageDialog
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
-import com.esri.arcgismaps.sample.stylegraphicswithsymbols.BuildConfig
 
 /**
  * The main SampleViewer app screen which showcases the list all sample categories,
@@ -134,9 +133,7 @@ fun HomeCategoryScreen(
  */
 @Composable
 fun CheckAccessToken() {
-    var isDialogDisplayed by remember {
-        mutableStateOf(BuildConfig.ACCESS_TOKEN == "DEFAULT_ACCESS_TOKEN")
-    }
+    var isDialogDisplayed by remember { mutableStateOf(false) }
     if (isDialogDisplayed) {
         MessageDialog(
             title = "Access token",

--- a/build-logic/convention/src/main/java/com/esri/arcgismaps/kotlin/build_logic/convention/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/java/com/esri/arcgismaps/kotlin/build_logic/convention/KotlinAndroid.kt
@@ -17,7 +17,6 @@ internal fun Project.configureKotlinAndroid(
         compileSdk = libs.findVersion("targetSdk").get().toString().toInt()
 
         defaultConfig {
-            buildConfigField("String", "ACCESS_TOKEN", project.properties["ACCESS_TOKEN"].toString())
             manifestPlaceholders["GOOGLE_API_KEY"] = project.properties["GOOGLE_API_KEY"].toString()
             minSdk = libs.findVersion("minSdk").get().toString().toInt()
         }

--- a/samples-lib/build.gradle.kts
+++ b/samples-lib/build.gradle.kts
@@ -3,18 +3,11 @@ import com.esri.arcgismaps.kotlin.build_logic.convention.implementation
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.sampleslib"
     buildFeatures {
-        buildConfig = true
         dataBinding = true
     }
 }

--- a/samples/add-3d-tiles-layer/build.gradle.kts
+++ b/samples/add-3d-tiles-layer/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.add3dtileslayer"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/add-3d-tiles-layer/src/main/java/com/esri/arcgismaps/sample/add3dtileslayer/MainActivity.kt
+++ b/samples/add-3d-tiles-layer/src/main/java/com/esri/arcgismaps/sample/add3dtileslayer/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.add3dtileslayer.screens.MainScreen
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 

--- a/samples/add-3d-tiles-layer/src/main/java/com/esri/arcgismaps/sample/add3dtileslayer/MainActivity.kt
+++ b/samples/add-3d-tiles-layer/src/main/java/com/esri/arcgismaps/sample/add3dtileslayer/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/add-building-scene-layer/build.gradle.kts
+++ b/samples/add-building-scene-layer/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.addbuildingscenelayer"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/add-building-scene-layer/src/main/java/com/esri/arcgismaps/sample/addbuildingscenelayer/MainActivity.kt
+++ b/samples/add-building-scene-layer/src/main/java/com/esri/arcgismaps/sample/addbuildingscenelayer/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         enableEdgeToEdge()
 
         setContent {

--- a/samples/add-building-scene-layer/src/main/java/com/esri/arcgismaps/sample/addbuildingscenelayer/MainActivity.kt
+++ b/samples/add-building-scene-layer/src/main/java/com/esri/arcgismaps/sample/addbuildingscenelayer/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.addbuildingscenelayer.screens.AddBuildingSceneLayerScreen
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 

--- a/samples/add-custom-dynamic-entity-data-source/build.gradle.kts
+++ b/samples/add-custom-dynamic-entity-data-source/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.addcustomdynamicentitydatasource"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/add-custom-dynamic-entity-data-source/src/main/java/com/esri/arcgismaps/sample/addcustomdynamicentitydatasource/MainActivity.kt
+++ b/samples/add-custom-dynamic-entity-data-source/src/main/java/com/esri/arcgismaps/sample/addcustomdynamicentitydatasource/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.addcustomdynamicentitydatasource.screens.MainScreen
 

--- a/samples/add-custom-dynamic-entity-data-source/src/main/java/com/esri/arcgismaps/sample/addcustomdynamicentitydatasource/MainActivity.kt
+++ b/samples/add-custom-dynamic-entity-data-source/src/main/java/com/esri/arcgismaps/sample/addcustomdynamicentitydatasource/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/add-dynamic-entity-layer/build.gradle.kts
+++ b/samples/add-dynamic-entity-layer/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.adddynamicentitylayer"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/add-dynamic-entity-layer/src/main/java/com/esri/arcgismaps/sample/adddynamicentitylayer/MainActivity.kt
+++ b/samples/add-dynamic-entity-layer/src/main/java/com/esri/arcgismaps/sample/adddynamicentitylayer/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.adddynamicentitylayer.screens.MainScreen
 

--- a/samples/add-dynamic-entity-layer/src/main/java/com/esri/arcgismaps/sample/adddynamicentitylayer/MainActivity.kt
+++ b/samples/add-dynamic-entity-layer/src/main/java/com/esri/arcgismaps/sample/adddynamicentitylayer/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         enableEdgeToEdge()
         setContent {
             SampleAppTheme {

--- a/samples/add-elevation-source-from-tile-package/build.gradle.kts
+++ b/samples/add-elevation-source-from-tile-package/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.addelevationsourcefromtilepackage"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/add-elevation-source-from-tile-package/src/main/java/com/esri/arcgismaps/sample/addelevationsourcefromtilepackage/MainActivity.kt
+++ b/samples/add-elevation-source-from-tile-package/src/main/java/com/esri/arcgismaps/sample/addelevationsourcefromtilepackage/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/add-elevation-source-from-tile-package/src/main/java/com/esri/arcgismaps/sample/addelevationsourcefromtilepackage/MainActivity.kt
+++ b/samples/add-elevation-source-from-tile-package/src/main/java/com/esri/arcgismaps/sample/addelevationsourcefromtilepackage/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.addelevationsourcefromtilepackage.screens.AddElevationSourceFromTilePackageScreen
 

--- a/samples/add-enc-exchange-set/build.gradle.kts
+++ b/samples/add-enc-exchange-set/build.gradle.kts
@@ -2,20 +2,11 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.addencexchangeset"
     // For view based samples
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/add-enc-exchange-set/src/main/java/com/esri/arcgismaps/sample/addencexchangeset/MainActivity.kt
+++ b/samples/add-enc-exchange-set/src/main/java/com/esri/arcgismaps/sample/addencexchangeset/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.addencexchangeset.screens.MainScreen
 

--- a/samples/add-enc-exchange-set/src/main/java/com/esri/arcgismaps/sample/addencexchangeset/MainActivity.kt
+++ b/samples/add-enc-exchange-set/src/main/java/com/esri/arcgismaps/sample/addencexchangeset/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/add-feature-collection-layer-from-portal-item/build.gradle.kts
+++ b/samples/add-feature-collection-layer-from-portal-item/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.addfeaturecollectionlayerfromportalitem"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/add-feature-collection-layer-from-portal-item/src/main/java/com/esri/arcgismaps/sample/addfeaturecollectionlayerfromportalitem/MainActivity.kt
+++ b/samples/add-feature-collection-layer-from-portal-item/src/main/java/com/esri/arcgismaps/sample/addfeaturecollectionlayerfromportalitem/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/add-feature-collection-layer-from-portal-item/src/main/java/com/esri/arcgismaps/sample/addfeaturecollectionlayerfromportalitem/MainActivity.kt
+++ b/samples/add-feature-collection-layer-from-portal-item/src/main/java/com/esri/arcgismaps/sample/addfeaturecollectionlayerfromportalitem/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.addfeaturecollectionlayerfromportalitem.screens.AddFeatureCollectionLayerFromPortalItemScreen
 

--- a/samples/add-feature-collection-layer-from-table/build.gradle.kts
+++ b/samples/add-feature-collection-layer-from-table/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.addfeaturecollectionlayerfromtable"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/add-feature-collection-layer-from-table/src/main/java/com/esri/arcgismaps/sample/addfeaturecollectionlayerfromtable/MainActivity.kt
+++ b/samples/add-feature-collection-layer-from-table/src/main/java/com/esri/arcgismaps/sample/addfeaturecollectionlayerfromtable/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/add-feature-collection-layer-from-table/src/main/java/com/esri/arcgismaps/sample/addfeaturecollectionlayerfromtable/MainActivity.kt
+++ b/samples/add-feature-collection-layer-from-table/src/main/java/com/esri/arcgismaps/sample/addfeaturecollectionlayerfromtable/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.addfeaturecollectionlayerfromtable.screens.AddFeatureCollectionLayerFromTableScreen
 

--- a/samples/add-feature-layers/build.gradle.kts
+++ b/samples/add-feature-layers/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/add-feature-layers/src/main/java/com/esri/arcgismaps/sample/addfeaturelayers/MainActivity.kt
+++ b/samples/add-feature-layers/src/main/java/com/esri/arcgismaps/sample/addfeaturelayers/MainActivity.kt
@@ -23,8 +23,6 @@ import android.widget.Toast
 import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.data.GeoPackage
 import com.arcgismaps.data.Geodatabase
 import com.arcgismaps.data.ServiceFeatureTable

--- a/samples/add-feature-layers/src/main/java/com/esri/arcgismaps/sample/addfeaturelayers/MainActivity.kt
+++ b/samples/add-feature-layers/src/main/java/com/esri/arcgismaps/sample/addfeaturelayers/MainActivity.kt
@@ -69,9 +69,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         lifecycle.addObserver(mapView)
         // set the map to be displayed in as the BasemapStyle topographic
         activityMainBinding.mapView.map = ArcGISMap(BasemapStyle.ArcGISTopographic)

--- a/samples/add-features-with-contingent-values/build.gradle.kts
+++ b/samples/add-features-with-contingent-values/build.gradle.kts
@@ -2,12 +2,6 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -15,7 +9,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/add-features-with-contingent-values/src/main/java/com/esri/arcgismaps/sample/addfeatureswithcontingentvalues/MainActivity.kt
+++ b/samples/add-features-with-contingent-values/src/main/java/com/esri/arcgismaps/sample/addfeatureswithcontingentvalues/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.addfeatureswithcontingentvalues.screens.AddFeaturesWithContingentValuesScreen
 

--- a/samples/add-features-with-contingent-values/src/main/java/com/esri/arcgismaps/sample/addfeatureswithcontingentvalues/MainActivity.kt
+++ b/samples/add-features-with-contingent-values/src/main/java/com/esri/arcgismaps/sample/addfeatureswithcontingentvalues/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/add-integrated-mesh-layer/build.gradle.kts
+++ b/samples/add-integrated-mesh-layer/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.addintegratedmeshlayer"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/add-integrated-mesh-layer/src/main/java/com/esri/arcgismaps/sample/addintegratedmeshlayer/MainActivity.kt
+++ b/samples/add-integrated-mesh-layer/src/main/java/com/esri/arcgismaps/sample/addintegratedmeshlayer/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/add-integrated-mesh-layer/src/main/java/com/esri/arcgismaps/sample/addintegratedmeshlayer/MainActivity.kt
+++ b/samples/add-integrated-mesh-layer/src/main/java/com/esri/arcgismaps/sample/addintegratedmeshlayer/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.addintegratedmeshlayer.screens.AddIntegratedMeshLayerScreen
 

--- a/samples/add-kml-layer-with-network-links/build.gradle.kts
+++ b/samples/add-kml-layer-with-network-links/build.gradle.kts
@@ -2,20 +2,11 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.addkmllayerwithnetworklinks"
     // For view based samples
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/add-kml-layer-with-network-links/src/main/java/com/esri/arcgismaps/sample/addkmllayerwithnetworklinks/MainActivity.kt
+++ b/samples/add-kml-layer-with-network-links/src/main/java/com/esri/arcgismaps/sample/addkmllayerwithnetworklinks/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.addkmllayerwithnetworklinks.screens.MainScreen
 

--- a/samples/add-kml-layer-with-network-links/src/main/java/com/esri/arcgismaps/sample/addkmllayerwithnetworklinks/MainActivity.kt
+++ b/samples/add-kml-layer-with-network-links/src/main/java/com/esri/arcgismaps/sample/addkmllayerwithnetworklinks/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/add-kml-layer/build.gradle.kts
+++ b/samples/add-kml-layer/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.addkmllayer"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/add-kml-layer/src/main/java/com/esri/arcgismaps/sample/addkmllayer/MainActivity.kt
+++ b/samples/add-kml-layer/src/main/java/com/esri/arcgismaps/sample/addkmllayer/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/add-kml-layer/src/main/java/com/esri/arcgismaps/sample/addkmllayer/MainActivity.kt
+++ b/samples/add-kml-layer/src/main/java/com/esri/arcgismaps/sample/addkmllayer/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.addkmllayer.screens.AddKMLLayerScreen
 

--- a/samples/add-map-image-layer/build.gradle.kts
+++ b/samples/add-map-image-layer/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.addmapimagelayer"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/add-map-image-layer/src/main/java/com/esri/arcgismaps/sample/addmapimagelayer/MainActivity.kt
+++ b/samples/add-map-image-layer/src/main/java/com/esri/arcgismaps/sample/addmapimagelayer/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.addmapimagelayer.screens.AddMapImageLayerScreen
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 

--- a/samples/add-map-image-layer/src/main/java/com/esri/arcgismaps/sample/addmapimagelayer/MainActivity.kt
+++ b/samples/add-map-image-layer/src/main/java/com/esri/arcgismaps/sample/addmapimagelayer/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/add-point-cloud-layer-from-file/build.gradle.kts
+++ b/samples/add-point-cloud-layer-from-file/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.addpointcloudlayerfromfile"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/add-point-cloud-layer-from-file/src/main/java/com/esri/arcgismaps/sample/addpointcloudlayerfromfile/MainActivity.kt
+++ b/samples/add-point-cloud-layer-from-file/src/main/java/com/esri/arcgismaps/sample/addpointcloudlayerfromfile/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/add-point-cloud-layer-from-file/src/main/java/com/esri/arcgismaps/sample/addpointcloudlayerfromfile/MainActivity.kt
+++ b/samples/add-point-cloud-layer-from-file/src/main/java/com/esri/arcgismaps/sample/addpointcloudlayerfromfile/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.addpointcloudlayerfromfile.screens.AddPointCloudLayerFromFileScreen
 

--- a/samples/add-point-scene-layer/build.gradle.kts
+++ b/samples/add-point-scene-layer/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.addpointscenelayer"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/add-point-scene-layer/src/main/java/com/esri/arcgismaps/sample/addpointscenelayer/MainActivity.kt
+++ b/samples/add-point-scene-layer/src/main/java/com/esri/arcgismaps/sample/addpointscenelayer/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.addpointscenelayer.screens.AddPointSceneLayerScreen
 

--- a/samples/add-point-scene-layer/src/main/java/com/esri/arcgismaps/sample/addpointscenelayer/MainActivity.kt
+++ b/samples/add-point-scene-layer/src/main/java/com/esri/arcgismaps/sample/addpointscenelayer/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/add-raster-from-file/build.gradle.kts
+++ b/samples/add-raster-from-file/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.addrasterfromfile"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/add-raster-from-file/src/main/java/com/esri/arcgismaps/sample/addrasterfromfile/MainActivity.kt
+++ b/samples/add-raster-from-file/src/main/java/com/esri/arcgismaps/sample/addrasterfromfile/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.addrasterfromfile.screens.AddRasterFromFileScreen
 

--- a/samples/add-raster-from-file/src/main/java/com/esri/arcgismaps/sample/addrasterfromfile/MainActivity.kt
+++ b/samples/add-raster-from-file/src/main/java/com/esri/arcgismaps/sample/addrasterfromfile/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/add-raster-from-service/build.gradle.kts
+++ b/samples/add-raster-from-service/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.addrasterfromservice"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/add-raster-from-service/src/main/java/com/esri/arcgismaps/sample/addrasterfromservice/MainActivity.kt
+++ b/samples/add-raster-from-service/src/main/java/com/esri/arcgismaps/sample/addrasterfromservice/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/add-raster-from-service/src/main/java/com/esri/arcgismaps/sample/addrasterfromservice/MainActivity.kt
+++ b/samples/add-raster-from-service/src/main/java/com/esri/arcgismaps/sample/addrasterfromservice/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.addrasterfromservice.screens.AddRasterFromServiceScreen
 

--- a/samples/add-scene-layer-from-service/build.gradle.kts
+++ b/samples/add-scene-layer-from-service/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.addscenelayerfromservice"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/add-scene-layer-from-service/src/main/java/com/esri/arcgismaps/sample/addscenelayerfromservice/MainActivity.kt
+++ b/samples/add-scene-layer-from-service/src/main/java/com/esri/arcgismaps/sample/addscenelayerfromservice/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.addscenelayerfromservice.screens.AddSceneLayerFromServiceScreen
 

--- a/samples/add-scene-layer-from-service/src/main/java/com/esri/arcgismaps/sample/addscenelayerfromservice/MainActivity.kt
+++ b/samples/add-scene-layer-from-service/src/main/java/com/esri/arcgismaps/sample/addscenelayerfromservice/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/add-web-tiled-layer/build.gradle.kts
+++ b/samples/add-web-tiled-layer/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.addwebtiledlayer"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/add-web-tiled-layer/src/main/java/com/esri/arcgismaps/sample/addwebtiledlayer/MainActivity.kt
+++ b/samples/add-web-tiled-layer/src/main/java/com/esri/arcgismaps/sample/addwebtiledlayer/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.addwebtiledlayer.screens.AddWebTiledLayerScreen
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 

--- a/samples/add-web-tiled-layer/src/main/java/com/esri/arcgismaps/sample/addwebtiledlayer/MainActivity.kt
+++ b/samples/add-web-tiled-layer/src/main/java/com/esri/arcgismaps/sample/addwebtiledlayer/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/add-wfs-layer/build.gradle.kts
+++ b/samples/add-wfs-layer/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.addwfslayer"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/add-wfs-layer/src/main/java/com/esri/arcgismaps/sample/addwfslayer/MainActivity.kt
+++ b/samples/add-wfs-layer/src/main/java/com/esri/arcgismaps/sample/addwfslayer/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.addwfslayer.screens.AddWfsLayerScreen
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 

--- a/samples/add-wfs-layer/src/main/java/com/esri/arcgismaps/sample/addwfslayer/MainActivity.kt
+++ b/samples/add-wfs-layer/src/main/java/com/esri/arcgismaps/sample/addwfslayer/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/add-wms-layer/build.gradle.kts
+++ b/samples/add-wms-layer/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/add-wms-layer/src/main/java/com/esri/arcgismaps/sample/addwmslayer/MainActivity.kt
+++ b/samples/add-wms-layer/src/main/java/com/esri/arcgismaps/sample/addwmslayer/MainActivity.kt
@@ -46,9 +46,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         lifecycle.addObserver(mapView)
 
         // create and add a map with a light gray basemap style

--- a/samples/add-wms-layer/src/main/java/com/esri/arcgismaps/sample/addwmslayer/MainActivity.kt
+++ b/samples/add-wms-layer/src/main/java/com/esri/arcgismaps/sample/addwmslayer/MainActivity.kt
@@ -22,8 +22,6 @@ import android.util.Log
 import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.mapping.ArcGISMap
 import com.arcgismaps.mapping.BasemapStyle
 import com.arcgismaps.mapping.Viewpoint

--- a/samples/analyze-hotspots/build.gradle.kts
+++ b/samples/analyze-hotspots/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.analyzehotspots"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/analyze-hotspots/src/main/java/com/esri/arcgismaps/sample/analyzehotspots/MainActivity.kt
+++ b/samples/analyze-hotspots/src/main/java/com/esri/arcgismaps/sample/analyzehotspots/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.analyzehotspots.screens.MainScreen
 

--- a/samples/analyze-hotspots/src/main/java/com/esri/arcgismaps/sample/analyzehotspots/MainActivity.kt
+++ b/samples/analyze-hotspots/src/main/java/com/esri/arcgismaps/sample/analyzehotspots/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/analyze-network-with-subnetwork-trace/build.gradle.kts
+++ b/samples/analyze-network-with-subnetwork-trace/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/animate-images-with-image-overlay/build.gradle.kts
+++ b/samples/animate-images-with-image-overlay/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.animateimageswithimageoverlay"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/animate-images-with-image-overlay/src/main/java/com/esri/arcgismaps/sample/animateimageswithimageoverlay/MainActivity.kt
+++ b/samples/animate-images-with-image-overlay/src/main/java/com/esri/arcgismaps/sample/animateimageswithimageoverlay/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // Authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/animate-images-with-image-overlay/src/main/java/com/esri/arcgismaps/sample/animateimageswithimageoverlay/MainActivity.kt
+++ b/samples/animate-images-with-image-overlay/src/main/java/com/esri/arcgismaps/sample/animateimageswithimageoverlay/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.animateimageswithimageoverlay.screens.AnimateImagesWithImageOverlayScreen
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 

--- a/samples/apply-blend-renderer-to-hillshade/build.gradle.kts
+++ b/samples/apply-blend-renderer-to-hillshade/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.applyblendrenderertohillshade"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/apply-blend-renderer-to-hillshade/src/main/java/com/esri/arcgismaps/sample/applyblendrenderertohillshade/MainActivity.kt
+++ b/samples/apply-blend-renderer-to-hillshade/src/main/java/com/esri/arcgismaps/sample/applyblendrenderertohillshade/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/apply-blend-renderer-to-hillshade/src/main/java/com/esri/arcgismaps/sample/applyblendrenderertohillshade/MainActivity.kt
+++ b/samples/apply-blend-renderer-to-hillshade/src/main/java/com/esri/arcgismaps/sample/applyblendrenderertohillshade/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.applyblendrenderertohillshade.screens.ApplyBlendRendererToHillshadeScreen
 

--- a/samples/apply-class-breaks-renderer-to-sublayer/build.gradle.kts
+++ b/samples/apply-class-breaks-renderer-to-sublayer/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.applyclassbreaksrenderertosublayer"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/apply-class-breaks-renderer-to-sublayer/src/main/java/com/esri/arcgismaps/sample/applyclassbreaksrenderertosublayer/MainActivity.kt
+++ b/samples/apply-class-breaks-renderer-to-sublayer/src/main/java/com/esri/arcgismaps/sample/applyclassbreaksrenderertosublayer/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.applyclassbreaksrenderertosublayer.screens.ApplyClassBreaksRendererToSublayerScreen
 

--- a/samples/apply-class-breaks-renderer-to-sublayer/src/main/java/com/esri/arcgismaps/sample/applyclassbreaksrenderertosublayer/MainActivity.kt
+++ b/samples/apply-class-breaks-renderer-to-sublayer/src/main/java/com/esri/arcgismaps/sample/applyclassbreaksrenderertosublayer/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/apply-colormap-renderer-to-raster/build.gradle.kts
+++ b/samples/apply-colormap-renderer-to-raster/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.applycolormaprenderertoraster"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/apply-colormap-renderer-to-raster/src/main/java/com/esri/arcgismaps/sample/applycolormaprenderertoraster/MainActivity.kt
+++ b/samples/apply-colormap-renderer-to-raster/src/main/java/com/esri/arcgismaps/sample/applycolormaprenderertoraster/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.applycolormaprenderertoraster.screens.ApplyColormapRendererToRasterScreen
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 

--- a/samples/apply-colormap-renderer-to-raster/src/main/java/com/esri/arcgismaps/sample/applycolormaprenderertoraster/MainActivity.kt
+++ b/samples/apply-colormap-renderer-to-raster/src/main/java/com/esri/arcgismaps/sample/applycolormaprenderertoraster/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/apply-dictionary-renderer-to-feature-layer/build.gradle.kts
+++ b/samples/apply-dictionary-renderer-to-feature-layer/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/apply-dictionary-renderer-to-feature-layer/src/main/java/com/esri/arcgismaps/sample/applydictionaryrenderertofeaturelayer/MainActivity.kt
+++ b/samples/apply-dictionary-renderer-to-feature-layer/src/main/java/com/esri/arcgismaps/sample/applydictionaryrenderertofeaturelayer/MainActivity.kt
@@ -53,9 +53,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         lifecycle.addObserver(mapView)
 
         // create and add a map with a navigation night basemap style

--- a/samples/apply-dictionary-renderer-to-feature-layer/src/main/java/com/esri/arcgismaps/sample/applydictionaryrenderertofeaturelayer/MainActivity.kt
+++ b/samples/apply-dictionary-renderer-to-feature-layer/src/main/java/com/esri/arcgismaps/sample/applydictionaryrenderertofeaturelayer/MainActivity.kt
@@ -21,8 +21,6 @@ import android.util.Log
 import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.data.Geodatabase
 import com.arcgismaps.mapping.ArcGISMap
 import com.arcgismaps.mapping.BasemapStyle

--- a/samples/apply-dictionary-renderer-to-graphics-overlay/build.gradle.kts
+++ b/samples/apply-dictionary-renderer-to-graphics-overlay/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.applydictionaryrenderertographicsoverlay"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/apply-dictionary-renderer-to-graphics-overlay/src/main/java/com/esri/arcgismaps/sample/applydictionaryrenderertographicsoverlay/MainActivity.kt
+++ b/samples/apply-dictionary-renderer-to-graphics-overlay/src/main/java/com/esri/arcgismaps/sample/applydictionaryrenderertographicsoverlay/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/apply-dictionary-renderer-to-graphics-overlay/src/main/java/com/esri/arcgismaps/sample/applydictionaryrenderertographicsoverlay/MainActivity.kt
+++ b/samples/apply-dictionary-renderer-to-graphics-overlay/src/main/java/com/esri/arcgismaps/sample/applydictionaryrenderertographicsoverlay/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.applydictionaryrenderertographicsoverlay.screens.ApplyDictionaryRendererToGraphicsOverlayScreen
 

--- a/samples/apply-function-to-raster-from-service/build.gradle.kts
+++ b/samples/apply-function-to-raster-from-service/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/apply-function-to-raster-from-service/src/main/java/com/esri/arcgismaps/sample/applyfunctiontorasterfromservice/MainActivity.kt
+++ b/samples/apply-function-to-raster-from-service/src/main/java/com/esri/arcgismaps/sample/applyfunctiontorasterfromservice/MainActivity.kt
@@ -55,9 +55,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         lifecycle.addObserver(mapView)
 
         // create and add a map with a dark gray basemap style

--- a/samples/apply-function-to-raster-from-service/src/main/java/com/esri/arcgismaps/sample/applyfunctiontorasterfromservice/MainActivity.kt
+++ b/samples/apply-function-to-raster-from-service/src/main/java/com/esri/arcgismaps/sample/applyfunctiontorasterfromservice/MainActivity.kt
@@ -21,8 +21,6 @@ import android.util.Log
 import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.LoadStatus
 import com.arcgismaps.mapping.ArcGISMap
 import com.arcgismaps.mapping.BasemapStyle

--- a/samples/apply-hillshade-renderer-to-raster/build.gradle.kts
+++ b/samples/apply-hillshade-renderer-to-raster/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.applyhillshaderenderertoraster"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/apply-hillshade-renderer-to-raster/src/main/java/com/esri/arcgismaps/sample/applyhillshaderenderertoraster/MainActivity.kt
+++ b/samples/apply-hillshade-renderer-to-raster/src/main/java/com/esri/arcgismaps/sample/applyhillshaderenderertoraster/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.applyhillshaderenderertoraster.screens.ApplyHillshadeRendererToRasterScreen
 

--- a/samples/apply-hillshade-renderer-to-raster/src/main/java/com/esri/arcgismaps/sample/applyhillshaderenderertoraster/MainActivity.kt
+++ b/samples/apply-hillshade-renderer-to-raster/src/main/java/com/esri/arcgismaps/sample/applyhillshaderenderertoraster/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/apply-map-algebra/build.gradle.kts
+++ b/samples/apply-map-algebra/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.applymapalgebra"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/apply-map-algebra/src/main/java/com/esri/arcgismaps/sample/applymapalgebra/MainActivity.kt
+++ b/samples/apply-map-algebra/src/main/java/com/esri/arcgismaps/sample/applymapalgebra/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/apply-map-algebra/src/main/java/com/esri/arcgismaps/sample/applymapalgebra/MainActivity.kt
+++ b/samples/apply-map-algebra/src/main/java/com/esri/arcgismaps/sample/applymapalgebra/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.applymapalgebra.screens.ApplyMapAlgebraScreen
 

--- a/samples/apply-mosaic-rule-to-rasters/build.gradle.kts
+++ b/samples/apply-mosaic-rule-to-rasters/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.applymosaicruletorasters"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/apply-mosaic-rule-to-rasters/src/main/java/com/esri/arcgismaps/sample/applymosaicruletorasters/MainActivity.kt
+++ b/samples/apply-mosaic-rule-to-rasters/src/main/java/com/esri/arcgismaps/sample/applymosaicruletorasters/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.applymosaicruletorasters.screens.ApplyMosaicRuleToRastersScreen
 

--- a/samples/apply-mosaic-rule-to-rasters/src/main/java/com/esri/arcgismaps/sample/applymosaicruletorasters/MainActivity.kt
+++ b/samples/apply-mosaic-rule-to-rasters/src/main/java/com/esri/arcgismaps/sample/applymosaicruletorasters/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/apply-raster-rendering-rule/build.gradle.kts
+++ b/samples/apply-raster-rendering-rule/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.applyrasterrenderingrule"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/apply-raster-rendering-rule/src/main/java/com/esri/arcgismaps/sample/applyrasterrenderingrule/MainActivity.kt
+++ b/samples/apply-raster-rendering-rule/src/main/java/com/esri/arcgismaps/sample/applyrasterrenderingrule/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.applyrasterrenderingrule.screens.ApplyRasterRenderingRuleScreen
 

--- a/samples/apply-raster-rendering-rule/src/main/java/com/esri/arcgismaps/sample/applyrasterrenderingrule/MainActivity.kt
+++ b/samples/apply-raster-rendering-rule/src/main/java/com/esri/arcgismaps/sample/applyrasterrenderingrule/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/apply-renderers-to-scene-layer/build.gradle.kts
+++ b/samples/apply-renderers-to-scene-layer/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.applyrendererstoscenelayer"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/apply-renderers-to-scene-layer/src/main/java/com/esri/arcgismaps/sample/applyrendererstoscenelayer/MainActivity.kt
+++ b/samples/apply-renderers-to-scene-layer/src/main/java/com/esri/arcgismaps/sample/applyrendererstoscenelayer/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/apply-renderers-to-scene-layer/src/main/java/com/esri/arcgismaps/sample/applyrendererstoscenelayer/MainActivity.kt
+++ b/samples/apply-renderers-to-scene-layer/src/main/java/com/esri/arcgismaps/sample/applyrendererstoscenelayer/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.applyrendererstoscenelayer.screens.ApplyRenderersToSceneLayerScreen
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 

--- a/samples/apply-scene-property-expressions/build.gradle.kts
+++ b/samples/apply-scene-property-expressions/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.applyscenepropertyexpressions"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/apply-scene-property-expressions/src/main/java/com/esri/arcgismaps/sample/applyscenepropertyexpressions/MainActivity.kt
+++ b/samples/apply-scene-property-expressions/src/main/java/com/esri/arcgismaps/sample/applyscenepropertyexpressions/MainActivity.kt
@@ -23,19 +23,13 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
-import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.applyscenepropertyexpressions.screens.ApplyScenePropertyExpressionsScreen
-import com.esri.arcgismaps.sample.sampleslib.BuildConfig
+import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 
 class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/apply-simple-renderer-to-feature-layer/build.gradle.kts
+++ b/samples/apply-simple-renderer-to-feature-layer/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.applysimplerenderertofeaturelayer"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/apply-simple-renderer-to-feature-layer/src/main/java/com/esri/arcgismaps/sample/applysimplerenderertofeaturelayer/MainActivity.kt
+++ b/samples/apply-simple-renderer-to-feature-layer/src/main/java/com/esri/arcgismaps/sample/applysimplerenderertofeaturelayer/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.applysimplerenderertofeaturelayer.screens.ApplySimpleRendererToFeatureLayerScreen
 

--- a/samples/apply-simple-renderer-to-feature-layer/src/main/java/com/esri/arcgismaps/sample/applysimplerenderertofeaturelayer/MainActivity.kt
+++ b/samples/apply-simple-renderer-to-feature-layer/src/main/java/com/esri/arcgismaps/sample/applysimplerenderertofeaturelayer/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/apply-simple-renderer-to-graphics-overlay/build.gradle.kts
+++ b/samples/apply-simple-renderer-to-graphics-overlay/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.applysimplerenderertographicsoverlay"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/apply-simple-renderer-to-graphics-overlay/src/main/java/com/esri/arcgismaps/sample/applysimplerenderertographicsoverlay/MainActivity.kt
+++ b/samples/apply-simple-renderer-to-graphics-overlay/src/main/java/com/esri/arcgismaps/sample/applysimplerenderertographicsoverlay/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.applysimplerenderertographicsoverlay.screens.ApplySimpleRendererToGraphicsOverlayScreen
 

--- a/samples/apply-simple-renderer-to-graphics-overlay/src/main/java/com/esri/arcgismaps/sample/applysimplerenderertographicsoverlay/MainActivity.kt
+++ b/samples/apply-simple-renderer-to-graphics-overlay/src/main/java/com/esri/arcgismaps/sample/applysimplerenderertographicsoverlay/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/apply-stretch-renderer/build.gradle.kts
+++ b/samples/apply-stretch-renderer/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.applystretchrenderer"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/apply-stretch-renderer/src/main/java/com/esri/arcgismaps/sample/applystretchrenderer/MainActivity.kt
+++ b/samples/apply-stretch-renderer/src/main/java/com/esri/arcgismaps/sample/applystretchrenderer/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/apply-stretch-renderer/src/main/java/com/esri/arcgismaps/sample/applystretchrenderer/MainActivity.kt
+++ b/samples/apply-stretch-renderer/src/main/java/com/esri/arcgismaps/sample/applystretchrenderer/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.applystretchrenderer.screens.ApplyStretchRendererScreen
 

--- a/samples/apply-style-to-wms-layer/build.gradle.kts
+++ b/samples/apply-style-to-wms-layer/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.applystyletowmslayer"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/apply-style-to-wms-layer/src/main/java/com/esri/arcgismaps/sample/applystyletowmslayer/MainActivity.kt
+++ b/samples/apply-style-to-wms-layer/src/main/java/com/esri/arcgismaps/sample/applystyletowmslayer/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/apply-style-to-wms-layer/src/main/java/com/esri/arcgismaps/sample/applystyletowmslayer/MainActivity.kt
+++ b/samples/apply-style-to-wms-layer/src/main/java/com/esri/arcgismaps/sample/applystyletowmslayer/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.applystyletowmslayer.screens.ApplyStyleToWmsLayerScreen
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 

--- a/samples/apply-symbology-to-shapefile/build.gradle.kts
+++ b/samples/apply-symbology-to-shapefile/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.applysymbologytoshapefile"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/apply-symbology-to-shapefile/src/main/java/com/esri/arcgismaps/sample/applysymbologytoshapefile/MainActivity.kt
+++ b/samples/apply-symbology-to-shapefile/src/main/java/com/esri/arcgismaps/sample/applysymbologytoshapefile/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/apply-symbology-to-shapefile/src/main/java/com/esri/arcgismaps/sample/applysymbologytoshapefile/MainActivity.kt
+++ b/samples/apply-symbology-to-shapefile/src/main/java/com/esri/arcgismaps/sample/applysymbologytoshapefile/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.applysymbologytoshapefile.screens.ApplySymbologyToShapefileScreen
 

--- a/samples/apply-terrain-exaggeration/build.gradle.kts
+++ b/samples/apply-terrain-exaggeration/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.applyterrainexaggeration"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/apply-terrain-exaggeration/src/main/java/com/esri/arcgismaps/sample/applyterrainexaggeration/MainActivity.kt
+++ b/samples/apply-terrain-exaggeration/src/main/java/com/esri/arcgismaps/sample/applyterrainexaggeration/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/apply-terrain-exaggeration/src/main/java/com/esri/arcgismaps/sample/applyterrainexaggeration/MainActivity.kt
+++ b/samples/apply-terrain-exaggeration/src/main/java/com/esri/arcgismaps/sample/applyterrainexaggeration/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.applyterrainexaggeration.screens.ApplyTerrainExaggerationScreen
 

--- a/samples/apply-unique-value-renderer/build.gradle.kts
+++ b/samples/apply-unique-value-renderer/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.applyuniquevaluerenderer"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/apply-unique-value-renderer/src/main/java/com/esri/arcgismaps/sample/applyuniquevaluerenderer/MainActivity.kt
+++ b/samples/apply-unique-value-renderer/src/main/java/com/esri/arcgismaps/sample/applyuniquevaluerenderer/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/apply-unique-value-renderer/src/main/java/com/esri/arcgismaps/sample/applyuniquevaluerenderer/MainActivity.kt
+++ b/samples/apply-unique-value-renderer/src/main/java/com/esri/arcgismaps/sample/applyuniquevaluerenderer/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.applyuniquevaluerenderer.screens.ApplyUniqueValueRendererScreen
 

--- a/samples/augment-reality-to-collect-data/src/main/java/com/esri/arcgismaps/sample/augmentrealitytocollectdata/MainActivity.kt
+++ b/samples/augment-reality-to-collect-data/src/main/java/com/esri/arcgismaps/sample/augmentrealitytocollectdata/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.augmentrealitytocollectdata.screens.AugmentRealityToCollectDataScreen
 

--- a/samples/augment-reality-to-collect-data/src/main/java/com/esri/arcgismaps/sample/augmentrealitytocollectdata/MainActivity.kt
+++ b/samples/augment-reality-to-collect-data/src/main/java/com/esri/arcgismaps/sample/augmentrealitytocollectdata/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/augment-reality-to-navigate-route/src/main/java/com/esri/arcgismaps/sample/augmentrealitytonavigateroute/MainActivity.kt
+++ b/samples/augment-reality-to-navigate-route/src/main/java/com/esri/arcgismaps/sample/augmentrealitytonavigateroute/MainActivity.kt
@@ -25,7 +25,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.navigation.compose.rememberNavController
-import com.arcgismaps.ApiKey
 import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.augmentrealitytonavigateroute.components.SharedRepository
 import com.esri.arcgismaps.sample.augmentrealitytonavigateroute.navigation.AugmentRealityToNavigateRouteNavGraph

--- a/samples/augment-reality-to-navigate-route/src/main/java/com/esri/arcgismaps/sample/augmentrealitytonavigateroute/MainActivity.kt
+++ b/samples/augment-reality-to-navigate-route/src/main/java/com/esri/arcgismaps/sample/augmentrealitytonavigateroute/MainActivity.kt
@@ -54,9 +54,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         ArcGISEnvironment.applicationContext = applicationContext
 
         val hasNonDefaultAPIKey = BuildConfig.GOOGLE_API_KEY != "DEFAULT_GOOGLE_API_KEY"

--- a/samples/augment-reality-to-show-hidden-infrastructure/src/main/java/com/esri/arcgismaps/sample/augmentrealitytoshowhiddeninfrastructure/MainActivity.kt
+++ b/samples/augment-reality-to-show-hidden-infrastructure/src/main/java/com/esri/arcgismaps/sample/augmentrealitytoshowhiddeninfrastructure/MainActivity.kt
@@ -54,9 +54,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         ArcGISEnvironment.applicationContext = applicationContext
 
         val hasNonDefaultAPIKey = BuildConfig.GOOGLE_API_KEY != "DEFAULT_GOOGLE_API_KEY"

--- a/samples/augment-reality-to-show-hidden-infrastructure/src/main/java/com/esri/arcgismaps/sample/augmentrealitytoshowhiddeninfrastructure/MainActivity.kt
+++ b/samples/augment-reality-to-show-hidden-infrastructure/src/main/java/com/esri/arcgismaps/sample/augmentrealitytoshowhiddeninfrastructure/MainActivity.kt
@@ -25,7 +25,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.navigation.compose.rememberNavController
-import com.arcgismaps.ApiKey
 import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.augmentrealitytoshowhiddeninfrastructure.components.SharedRepository
 import com.esri.arcgismaps.sample.augmentrealitytoshowhiddeninfrastructure.navigation.AugmentRealityToShowHiddenInfrastructureNavGraph

--- a/samples/augment-reality-to-show-tabletop-scene/src/main/java/com/esri/arcgismaps/sample/augmentrealitytoshowtabletopscene/MainActivity.kt
+++ b/samples/augment-reality-to-show-tabletop-scene/src/main/java/com/esri/arcgismaps/sample/augmentrealitytoshowtabletopscene/MainActivity.kt
@@ -39,9 +39,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/augment-reality-to-show-tabletop-scene/src/main/java/com/esri/arcgismaps/sample/augmentrealitytoshowtabletopscene/MainActivity.kt
+++ b/samples/augment-reality-to-show-tabletop-scene/src/main/java/com/esri/arcgismaps/sample/augmentrealitytoshowtabletopscene/MainActivity.kt
@@ -24,8 +24,6 @@ import androidx.activity.viewModels
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.augmentrealitytoshowtabletopscene.components.AugmentRealityToShowTabletopSceneViewModel
 import com.esri.arcgismaps.sample.augmentrealitytoshowtabletopscene.screens.DisplaySceneInTabletopARScreen
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme

--- a/samples/authenticate-with-oauth/build.gradle.kts
+++ b/samples/authenticate-with-oauth/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.authenticatewithoauth"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/browse-building-floors/build.gradle.kts
+++ b/samples/browse-building-floors/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/browse-building-floors/src/main/java/com/esri/arcgismaps/sample/browsebuildingfloors/MainActivity.kt
+++ b/samples/browse-building-floors/src/main/java/com/esri/arcgismaps/sample/browsebuildingfloors/MainActivity.kt
@@ -58,9 +58,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         lifecycle.addObserver(mapView)
 
         // load the portal and create a map from the portal item

--- a/samples/browse-building-floors/src/main/java/com/esri/arcgismaps/sample/browsebuildingfloors/MainActivity.kt
+++ b/samples/browse-building-floors/src/main/java/com/esri/arcgismaps/sample/browsebuildingfloors/MainActivity.kt
@@ -29,8 +29,6 @@ import androidx.annotation.LayoutRes
 import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.mapping.ArcGISMap
 import com.arcgismaps.mapping.PortalItem
 import com.arcgismaps.mapping.floor.FloorLevel

--- a/samples/browse-ogc-api-feature-service/build.gradle.kts
+++ b/samples/browse-ogc-api-feature-service/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.browseogcapifeatureservice"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/browse-ogc-api-feature-service/src/main/java/com/esri/arcgismaps/sample/browseogcapifeatureservice/MainActivity.kt
+++ b/samples/browse-ogc-api-feature-service/src/main/java/com/esri/arcgismaps/sample/browseogcapifeatureservice/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.browseogcapifeatureservice.screens.BrowseOgcApiFeatureServiceScreen
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 

--- a/samples/browse-ogc-api-feature-service/src/main/java/com/esri/arcgismaps/sample/browseogcapifeatureservice/MainActivity.kt
+++ b/samples/browse-ogc-api-feature-service/src/main/java/com/esri/arcgismaps/sample/browseogcapifeatureservice/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/change-camera-controller/build.gradle.kts
+++ b/samples/change-camera-controller/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/change-camera-controller/src/main/java/com/esri/arcgismaps/sample/changecameracontroller/MainActivity.kt
+++ b/samples/change-camera-controller/src/main/java/com/esri/arcgismaps/sample/changecameracontroller/MainActivity.kt
@@ -123,9 +123,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         lifecycle.addObserver(sceneView)
 
         // create and add a scene with an imagery basemap style

--- a/samples/change-camera-controller/src/main/java/com/esri/arcgismaps/sample/changecameracontroller/MainActivity.kt
+++ b/samples/change-camera-controller/src/main/java/com/esri/arcgismaps/sample/changecameracontroller/MainActivity.kt
@@ -22,8 +22,6 @@ import android.widget.ArrayAdapter
 import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.geometry.Point
 import com.arcgismaps.geometry.SpatialReference
 import com.arcgismaps.mapping.ArcGISScene

--- a/samples/change-viewpoint/build.gradle.kts
+++ b/samples/change-viewpoint/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/change-viewpoint/src/main/java/com/esri/arcgismaps/sample/changeviewpoint/MainActivity.kt
+++ b/samples/change-viewpoint/src/main/java/com/esri/arcgismaps/sample/changeviewpoint/MainActivity.kt
@@ -48,9 +48,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         // add the MapView to the lifecycle
         lifecycle.addObserver(mapView)
         // create and add a map with a imagery basemap style

--- a/samples/change-viewpoint/src/main/java/com/esri/arcgismaps/sample/changeviewpoint/MainActivity.kt
+++ b/samples/change-viewpoint/src/main/java/com/esri/arcgismaps/sample/changeviewpoint/MainActivity.kt
@@ -21,8 +21,6 @@ import android.view.View
 import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.geometry.Point
 import com.arcgismaps.geometry.PolylineBuilder
 import com.arcgismaps.geometry.SpatialReference

--- a/samples/clip-geometry/build.gradle.kts
+++ b/samples/clip-geometry/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.clipgeometry"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/clip-geometry/src/main/java/com/esri/arcgismaps/sample/clipgeometry/MainActivity.kt
+++ b/samples/clip-geometry/src/main/java/com/esri/arcgismaps/sample/clipgeometry/MainActivity.kt
@@ -33,9 +33,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/clip-geometry/src/main/java/com/esri/arcgismaps/sample/clipgeometry/MainActivity.kt
+++ b/samples/clip-geometry/src/main/java/com/esri/arcgismaps/sample/clipgeometry/MainActivity.kt
@@ -24,8 +24,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.clipgeometry.screens.ClipGeometryScreen
 

--- a/samples/configure-basemap-style-parameters/build.gradle.kts
+++ b/samples/configure-basemap-style-parameters/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.configurebasemapstyleparameters"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/configure-basemap-style-parameters/src/main/java/com/esri/arcgismaps/sample/configurebasemapstyleparameters/MainActivity.kt
+++ b/samples/configure-basemap-style-parameters/src/main/java/com/esri/arcgismaps/sample/configurebasemapstyleparameters/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.configurebasemapstyleparameters.screens.MainScreen
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 

--- a/samples/configure-basemap-style-parameters/src/main/java/com/esri/arcgismaps/sample/configurebasemapstyleparameters/MainActivity.kt
+++ b/samples/configure-basemap-style-parameters/src/main/java/com/esri/arcgismaps/sample/configurebasemapstyleparameters/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         enableEdgeToEdge()
         setContent {
             SampleAppTheme {

--- a/samples/configure-clusters/build.gradle.kts
+++ b/samples/configure-clusters/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.configureclusters"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/configure-clusters/src/main/java/com/esri/arcgismaps/sample/configureclusters/MainActivity.kt
+++ b/samples/configure-clusters/src/main/java/com/esri/arcgismaps/sample/configureclusters/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.configureclusters.screens.MainScreen
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 

--- a/samples/configure-clusters/src/main/java/com/esri/arcgismaps/sample/configureclusters/MainActivity.kt
+++ b/samples/configure-clusters/src/main/java/com/esri/arcgismaps/sample/configureclusters/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/configure-scene-environment/build.gradle.kts
+++ b/samples/configure-scene-environment/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.configuresceneenvironment"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/configure-scene-environment/src/main/java/com/esri/arcgismaps/sample/configuresceneenvironment/MainActivity.kt
+++ b/samples/configure-scene-environment/src/main/java/com/esri/arcgismaps/sample/configuresceneenvironment/MainActivity.kt
@@ -22,19 +22,13 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
-import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.configuresceneenvironment.screens.ConfigureSceneEnvironmentScreen
-import com.esri.arcgismaps.sample.sampleslib.BuildConfig
+import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 
 class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/create-and-edit-geometries/build.gradle.kts
+++ b/samples/create-and-edit-geometries/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.createandeditgeometries"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/create-and-edit-geometries/src/main/java/com/esri/arcgismaps/sample/createandeditgeometries/MainActivity.kt
+++ b/samples/create-and-edit-geometries/src/main/java/com/esri/arcgismaps/sample/createandeditgeometries/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.createandeditgeometries.screens.CreateAndEditGeometriesScreen
 

--- a/samples/create-and-edit-geometries/src/main/java/com/esri/arcgismaps/sample/createandeditgeometries/MainActivity.kt
+++ b/samples/create-and-edit-geometries/src/main/java/com/esri/arcgismaps/sample/createandeditgeometries/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/create-and-save-map/build.gradle.kts
+++ b/samples/create-and-save-map/build.gradle.kts
@@ -2,20 +2,11 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.createandsavemap"
     // For view based samples
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/create-buffers-around-points/build.gradle.kts
+++ b/samples/create-buffers-around-points/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.createbuffersaroundpoints"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/create-buffers-around-points/src/main/java/com/esri/arcgismaps/sample/createbuffersaroundpoints/MainActivity.kt
+++ b/samples/create-buffers-around-points/src/main/java/com/esri/arcgismaps/sample/createbuffersaroundpoints/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/create-buffers-around-points/src/main/java/com/esri/arcgismaps/sample/createbuffersaroundpoints/MainActivity.kt
+++ b/samples/create-buffers-around-points/src/main/java/com/esri/arcgismaps/sample/createbuffersaroundpoints/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.createbuffersaroundpoints.screens.CreateBuffersAroundPointsScreen
 

--- a/samples/create-convex-hull-around-points/build.gradle.kts
+++ b/samples/create-convex-hull-around-points/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/create-convex-hull-around-points/src/main/java/com/esri/arcgismaps/sample/createconvexhullaroundpoints/MainActivity.kt
+++ b/samples/create-convex-hull-around-points/src/main/java/com/esri/arcgismaps/sample/createconvexhullaroundpoints/MainActivity.kt
@@ -22,8 +22,6 @@ import android.util.Log
 import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.Color
 import com.arcgismaps.geometry.Geometry
 import com.arcgismaps.geometry.GeometryEngine

--- a/samples/create-convex-hull-around-points/src/main/java/com/esri/arcgismaps/sample/createconvexhullaroundpoints/MainActivity.kt
+++ b/samples/create-convex-hull-around-points/src/main/java/com/esri/arcgismaps/sample/createconvexhullaroundpoints/MainActivity.kt
@@ -92,9 +92,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         lifecycle.addObserver(mapView)
 
         // add point and convex hull graphics to the graphics overlay

--- a/samples/create-kml-multi-track/build.gradle.kts
+++ b/samples/create-kml-multi-track/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.createkmlmultitrack"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/create-kml-multi-track/src/main/java/com/esri/arcgismaps/sample/createkmlmultitrack/MainActivity.kt
+++ b/samples/create-kml-multi-track/src/main/java/com/esri/arcgismaps/sample/createkmlmultitrack/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.createkmlmultitrack.screens.CreateKMLMultiTrackScreen
 

--- a/samples/create-kml-multi-track/src/main/java/com/esri/arcgismaps/sample/createkmlmultitrack/MainActivity.kt
+++ b/samples/create-kml-multi-track/src/main/java/com/esri/arcgismaps/sample/createkmlmultitrack/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/create-mobile-geodatabase/build.gradle.kts
+++ b/samples/create-mobile-geodatabase/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/create-mobile-geodatabase/src/main/java/com/esri/arcgismaps/sample/createmobilegeodatabase/MainActivity.kt
+++ b/samples/create-mobile-geodatabase/src/main/java/com/esri/arcgismaps/sample/createmobilegeodatabase/MainActivity.kt
@@ -84,9 +84,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         lifecycle.addObserver(mapView)
 
         lifecycleScope.launch {

--- a/samples/create-mobile-geodatabase/src/main/java/com/esri/arcgismaps/sample/createmobilegeodatabase/MainActivity.kt
+++ b/samples/create-mobile-geodatabase/src/main/java/com/esri/arcgismaps/sample/createmobilegeodatabase/MainActivity.kt
@@ -25,8 +25,6 @@ import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.core.content.FileProvider
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.LoadStatus
 import com.arcgismaps.data.FieldDescription
 import com.arcgismaps.data.FieldType

--- a/samples/create-planar-and-geodetic-buffers/build.gradle.kts
+++ b/samples/create-planar-and-geodetic-buffers/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/create-planar-and-geodetic-buffers/src/main/java/com/esri/arcgismaps/sample/createplanarandgeodeticbuffers/MainActivity.kt
+++ b/samples/create-planar-and-geodetic-buffers/src/main/java/com/esri/arcgismaps/sample/createplanarandgeodeticbuffers/MainActivity.kt
@@ -51,9 +51,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         // set up data binding for the activity
         val activityMainBinding: CreatePlanarAndGeodeticBuffersActivityMainBinding =

--- a/samples/create-planar-and-geodetic-buffers/src/main/java/com/esri/arcgismaps/sample/createplanarandgeodeticbuffers/MainActivity.kt
+++ b/samples/create-planar-and-geodetic-buffers/src/main/java/com/esri/arcgismaps/sample/createplanarandgeodeticbuffers/MainActivity.kt
@@ -22,8 +22,6 @@ import android.widget.TextView
 import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.Color
 import com.arcgismaps.geometry.GeodeticCurveType
 import com.arcgismaps.geometry.GeometryEngine

--- a/samples/create-symbol-styles-from-web-styles/build.gradle.kts
+++ b/samples/create-symbol-styles-from-web-styles/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.createsymbolstylesfromwebstyles"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/create-symbol-styles-from-web-styles/src/main/java/com/esri/arcgismaps/sample/createsymbolstylesfromwebstyles/MainActivity.kt
+++ b/samples/create-symbol-styles-from-web-styles/src/main/java/com/esri/arcgismaps/sample/createsymbolstylesfromwebstyles/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.createsymbolstylesfromwebstyles.screens.CreateSymbolStylesFromWebStylesScreen
 

--- a/samples/create-symbol-styles-from-web-styles/src/main/java/com/esri/arcgismaps/sample/createsymbolstylesfromwebstyles/MainActivity.kt
+++ b/samples/create-symbol-styles-from-web-styles/src/main/java/com/esri/arcgismaps/sample/createsymbolstylesfromwebstyles/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/cut-geometry/build.gradle.kts
+++ b/samples/cut-geometry/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.cutgeometry"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/cut-geometry/src/main/java/com/esri/arcgismaps/sample/cutgeometry/MainActivity.kt
+++ b/samples/cut-geometry/src/main/java/com/esri/arcgismaps/sample/cutgeometry/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.cutgeometry.screens.CutGeometryScreen
 

--- a/samples/cut-geometry/src/main/java/com/esri/arcgismaps/sample/cutgeometry/MainActivity.kt
+++ b/samples/cut-geometry/src/main/java/com/esri/arcgismaps/sample/cutgeometry/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/display-alternate-symbols-at-different-scales/build.gradle.kts
+++ b/samples/display-alternate-symbols-at-different-scales/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.displayalternatesymbolsatdifferentscales"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/display-alternate-symbols-at-different-scales/src/main/java/com/esri/arcgismaps/sample/displayalternatesymbolsatdifferentscales/MainActivity.kt
+++ b/samples/display-alternate-symbols-at-different-scales/src/main/java/com/esri/arcgismaps/sample/displayalternatesymbolsatdifferentscales/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/display-alternate-symbols-at-different-scales/src/main/java/com/esri/arcgismaps/sample/displayalternatesymbolsatdifferentscales/MainActivity.kt
+++ b/samples/display-alternate-symbols-at-different-scales/src/main/java/com/esri/arcgismaps/sample/displayalternatesymbolsatdifferentscales/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.displayalternatesymbolsatdifferentscales.screens.DisplayAlternateSymbolsAtDifferentScalesScreen
 

--- a/samples/display-annotation/build.gradle.kts
+++ b/samples/display-annotation/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.displayannotation"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/display-annotation/src/main/java/com/esri/arcgismaps/sample/displayannotation/MainActivity.kt
+++ b/samples/display-annotation/src/main/java/com/esri/arcgismaps/sample/displayannotation/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.displayannotation.screens.DisplayAnnotationScreen
 

--- a/samples/display-annotation/src/main/java/com/esri/arcgismaps/sample/displayannotation/MainActivity.kt
+++ b/samples/display-annotation/src/main/java/com/esri/arcgismaps/sample/displayannotation/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/display-clusters/build.gradle.kts
+++ b/samples/display-clusters/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.displayclusters"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/display-clusters/src/main/java/com/esri/arcgismaps/sample/displayclusters/MainActivity.kt
+++ b/samples/display-clusters/src/main/java/com/esri/arcgismaps/sample/displayclusters/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.displayclusters.screens.MainScreen
 

--- a/samples/display-clusters/src/main/java/com/esri/arcgismaps/sample/displayclusters/MainActivity.kt
+++ b/samples/display-clusters/src/main/java/com/esri/arcgismaps/sample/displayclusters/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/display-composable-mapview/build.gradle.kts
+++ b/samples/display-composable-mapview/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.displaycomposablemapview"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/display-composable-mapview/src/main/java/com/esri/arcgismaps/sample/displaycomposablemapview/MainActivity.kt
+++ b/samples/display-composable-mapview/src/main/java/com/esri/arcgismaps/sample/displaycomposablemapview/MainActivity.kt
@@ -36,9 +36,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/display-composable-mapview/src/main/java/com/esri/arcgismaps/sample/displaycomposablemapview/MainActivity.kt
+++ b/samples/display-composable-mapview/src/main/java/com/esri/arcgismaps/sample/displaycomposablemapview/MainActivity.kt
@@ -24,8 +24,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.ui.Modifier
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.mapping.ArcGISMap
 import com.arcgismaps.mapping.BasemapStyle
 import com.arcgismaps.toolkit.geoviewcompose.MapView

--- a/samples/display-device-location-with-nmea-data-sources/build.gradle.kts
+++ b/samples/display-device-location-with-nmea-data-sources/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/display-device-location-with-nmea-data-sources/src/main/java/com/esri/arcgismaps/sample/displaydevicelocationwithnmeadatasources/MainActivity.kt
+++ b/samples/display-device-location-with-nmea-data-sources/src/main/java/com/esri/arcgismaps/sample/displaydevicelocationwithnmeadatasources/MainActivity.kt
@@ -24,8 +24,6 @@ import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.geometry.Point
 import com.arcgismaps.geometry.SpatialReference
 import com.arcgismaps.location.LocationDataSourceStatus

--- a/samples/display-device-location-with-nmea-data-sources/src/main/java/com/esri/arcgismaps/sample/displaydevicelocationwithnmeadatasources/MainActivity.kt
+++ b/samples/display-device-location-with-nmea-data-sources/src/main/java/com/esri/arcgismaps/sample/displaydevicelocationwithnmeadatasources/MainActivity.kt
@@ -97,9 +97,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         lifecycle.addObserver(mapView)
 
         // create and add a map with a navigation night basemap style

--- a/samples/display-dimensions/build.gradle.kts
+++ b/samples/display-dimensions/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/display-dimensions/src/main/java/com/esri/arcgismaps/sample/displaydimensions/MainActivity.kt
+++ b/samples/display-dimensions/src/main/java/com/esri/arcgismaps/sample/displaydimensions/MainActivity.kt
@@ -21,8 +21,6 @@ import android.util.Log
 import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.mapping.MobileMapPackage
 import com.arcgismaps.mapping.layers.DimensionLayer
 import com.esri.arcgismaps.sample.displaydimensions.databinding.DimensionsDialogLayoutBinding

--- a/samples/display-dimensions/src/main/java/com/esri/arcgismaps/sample/displaydimensions/MainActivity.kt
+++ b/samples/display-dimensions/src/main/java/com/esri/arcgismaps/sample/displaydimensions/MainActivity.kt
@@ -62,9 +62,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         lifecycle.addObserver(mapView)
 
         // check if the .mmpk file exits

--- a/samples/display-local-scene/build.gradle.kts
+++ b/samples/display-local-scene/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.displaylocalscene"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/display-local-scene/src/main/java/com/esri/arcgismaps/sample/displaylocalscene/MainActivity.kt
+++ b/samples/display-local-scene/src/main/java/com/esri/arcgismaps/sample/displaylocalscene/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/display-local-scene/src/main/java/com/esri/arcgismaps/sample/displaylocalscene/MainActivity.kt
+++ b/samples/display-local-scene/src/main/java/com/esri/arcgismaps/sample/displaylocalscene/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.displaylocalscene.screens.DisplayLocalSceneScreen
 

--- a/samples/display-map-from-mobile-map-package/build.gradle.kts
+++ b/samples/display-map-from-mobile-map-package/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.displaymapfrommobilemappackage"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/display-map-from-mobile-map-package/src/main/java/com/esri/arcgismaps/sample/displaymapfrommobilemappackage/MainActivity.kt
+++ b/samples/display-map-from-mobile-map-package/src/main/java/com/esri/arcgismaps/sample/displaymapfrommobilemappackage/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.displaymapfrommobilemappackage.screens.MainScreen
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 

--- a/samples/display-map-from-mobile-map-package/src/main/java/com/esri/arcgismaps/sample/displaymapfrommobilemappackage/MainActivity.kt
+++ b/samples/display-map-from-mobile-map-package/src/main/java/com/esri/arcgismaps/sample/displaymapfrommobilemappackage/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         enableEdgeToEdge()
         setContent {
             SampleAppTheme {

--- a/samples/display-map-from-portal-item/build.gradle.kts
+++ b/samples/display-map-from-portal-item/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.displaymapfromportalitem"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/display-map-from-portal-item/src/main/java/com/esri/arcgismaps/sample/displaymapfromportalitem/MainActivity.kt
+++ b/samples/display-map-from-portal-item/src/main/java/com/esri/arcgismaps/sample/displaymapfromportalitem/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.displaymapfromportalitem.screens.DisplayMapFromPortalItemScreen
 

--- a/samples/display-map-from-portal-item/src/main/java/com/esri/arcgismaps/sample/displaymapfromportalitem/MainActivity.kt
+++ b/samples/display-map-from-portal-item/src/main/java/com/esri/arcgismaps/sample/displaymapfromportalitem/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/display-map/build.gradle.kts
+++ b/samples/display-map/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/display-map/src/main/java/com/esri/arcgismaps/sample/displaymap/MainActivity.kt
+++ b/samples/display-map/src/main/java/com/esri/arcgismaps/sample/displaymap/MainActivity.kt
@@ -30,9 +30,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         // set up data binding for the activity
         val activityMainBinding: DisplayMapActivityMainBinding =

--- a/samples/display-map/src/main/java/com/esri/arcgismaps/sample/displaymap/MainActivity.kt
+++ b/samples/display-map/src/main/java/com/esri/arcgismaps/sample/displaymap/MainActivity.kt
@@ -19,8 +19,6 @@ package com.esri.arcgismaps.sample.displaymap
 import android.os.Bundle
 import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.mapping.ArcGISMap
 import com.arcgismaps.mapping.BasemapStyle
 import com.esri.arcgismaps.sample.displaymap.databinding.DisplayMapActivityMainBinding

--- a/samples/display-overview-map/build.gradle.kts
+++ b/samples/display-overview-map/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.displayoverviewmap"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/display-overview-map/src/main/java/com/esri/arcgismaps/sample/displayoverviewmap/MainActivity.kt
+++ b/samples/display-overview-map/src/main/java/com/esri/arcgismaps/sample/displayoverviewmap/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.displayoverviewmap.screens.DisplayOverviewMapScreen
 

--- a/samples/display-overview-map/src/main/java/com/esri/arcgismaps/sample/displayoverviewmap/MainActivity.kt
+++ b/samples/display-overview-map/src/main/java/com/esri/arcgismaps/sample/displayoverviewmap/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/display-scene-from-mobile-scene-package/build.gradle.kts
+++ b/samples/display-scene-from-mobile-scene-package/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.displayscenefrommobilescenepackage"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/display-scene-from-mobile-scene-package/src/main/java/com/esri/arcgismaps/sample/displayscenefrommobilescenepackage/MainActivity.kt
+++ b/samples/display-scene-from-mobile-scene-package/src/main/java/com/esri/arcgismaps/sample/displayscenefrommobilescenepackage/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.displayscenefrommobilescenepackage.screens.MainScreen
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 

--- a/samples/display-scene-from-mobile-scene-package/src/main/java/com/esri/arcgismaps/sample/displayscenefrommobilescenepackage/MainActivity.kt
+++ b/samples/display-scene-from-mobile-scene-package/src/main/java/com/esri/arcgismaps/sample/displayscenefrommobilescenepackage/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/display-scene/build.gradle.kts
+++ b/samples/display-scene/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/display-scene/src/main/java/com/esri/arcgismaps/sample/displayscene/MainActivity.kt
+++ b/samples/display-scene/src/main/java/com/esri/arcgismaps/sample/displayscene/MainActivity.kt
@@ -41,9 +41,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         lifecycle.addObserver(sceneView)
 
         // create an elevation source, and add this to the base surface of the scene

--- a/samples/display-scene/src/main/java/com/esri/arcgismaps/sample/displayscene/MainActivity.kt
+++ b/samples/display-scene/src/main/java/com/esri/arcgismaps/sample/displayscene/MainActivity.kt
@@ -19,8 +19,6 @@ package com.esri.arcgismaps.sample.displayscene
 import android.os.Bundle
 import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.mapping.ArcGISScene
 import com.arcgismaps.mapping.ArcGISTiledElevationSource
 import com.arcgismaps.mapping.BasemapStyle

--- a/samples/display-web-scene-from-portal-item/build.gradle.kts
+++ b/samples/display-web-scene-from-portal-item/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.displaywebscenefromportalitem"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/display-web-scene-from-portal-item/src/main/java/com/esri/arcgismaps/sample/displaywebscenefromportalitem/MainActivity.kt
+++ b/samples/display-web-scene-from-portal-item/src/main/java/com/esri/arcgismaps/sample/displaywebscenefromportalitem/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.displaywebscenefromportalitem.screens.DisplayWebSceneFromPortalItemScreen
 

--- a/samples/display-web-scene-from-portal-item/src/main/java/com/esri/arcgismaps/sample/displaywebscenefromportalitem/MainActivity.kt
+++ b/samples/display-web-scene-from-portal-item/src/main/java/com/esri/arcgismaps/sample/displaywebscenefromportalitem/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/download-preplanned-map-area/build.gradle.kts
+++ b/samples/download-preplanned-map-area/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.downloadpreplannedmaparea"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/download-preplanned-map-area/src/main/java/com/esri/arcgismaps/sample/downloadpreplannedmaparea/MainActivity.kt
+++ b/samples/download-preplanned-map-area/src/main/java/com/esri/arcgismaps/sample/downloadpreplannedmaparea/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.downloadpreplannedmaparea.screens.DownloadPreplannedMapAreaScreen
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import java.io.File

--- a/samples/download-preplanned-map-area/src/main/java/com/esri/arcgismaps/sample/downloadpreplannedmaparea/MainActivity.kt
+++ b/samples/download-preplanned-map-area/src/main/java/com/esri/arcgismaps/sample/downloadpreplannedmaparea/MainActivity.kt
@@ -40,9 +40,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         // Delete any existing offline maps, to reset sample state
         File(offlineMapPath).deleteRecursively()

--- a/samples/download-vector-tiles-to-local-cache/build.gradle.kts
+++ b/samples/download-vector-tiles-to-local-cache/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/download-vector-tiles-to-local-cache/src/main/java/com/esri/arcgismaps/sample/downloadvectortilestolocalcache/MainActivity.kt
+++ b/samples/download-vector-tiles-to-local-cache/src/main/java/com/esri/arcgismaps/sample/downloadvectortilestolocalcache/MainActivity.kt
@@ -84,9 +84,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         // add mapView to the lifecycle
         lifecycle.addObserver(mapView)
         lifecycle.addObserver(previewMapView)

--- a/samples/download-vector-tiles-to-local-cache/src/main/java/com/esri/arcgismaps/sample/downloadvectortilestolocalcache/MainActivity.kt
+++ b/samples/download-vector-tiles-to-local-cache/src/main/java/com/esri/arcgismaps/sample/downloadvectortilestolocalcache/MainActivity.kt
@@ -23,8 +23,6 @@ import android.view.ViewGroup
 import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.Color
 import com.arcgismaps.geometry.Envelope
 import com.arcgismaps.mapping.ArcGISMap

--- a/samples/edit-and-sync-features-with-feature-service/build.gradle.kts
+++ b/samples/edit-and-sync-features-with-feature-service/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.editandsyncfeatureswithfeatureservice"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/edit-and-sync-features-with-feature-service/src/main/java/com/esri/arcgismaps/sample/editandsyncfeatureswithfeatureservice/MainActivity.kt
+++ b/samples/edit-and-sync-features-with-feature-service/src/main/java/com/esri/arcgismaps/sample/editandsyncfeatureswithfeatureservice/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.editandsyncfeatureswithfeatureservice.screens.MainScreen
 

--- a/samples/edit-and-sync-features-with-feature-service/src/main/java/com/esri/arcgismaps/sample/editandsyncfeatureswithfeatureservice/MainActivity.kt
+++ b/samples/edit-and-sync-features-with-feature-service/src/main/java/com/esri/arcgismaps/sample/editandsyncfeatureswithfeatureservice/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/edit-feature-attachments/build.gradle.kts
+++ b/samples/edit-feature-attachments/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/edit-feature-attachments/src/main/java/com/esri/arcgismaps/sample/editfeatureattachments/MainActivity.kt
+++ b/samples/edit-feature-attachments/src/main/java/com/esri/arcgismaps/sample/editfeatureattachments/MainActivity.kt
@@ -32,8 +32,6 @@ import androidx.core.content.FileProvider
 import androidx.core.graphics.drawable.toDrawable
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.data.ArcGISFeature
 import com.arcgismaps.data.Attachment
 import com.arcgismaps.data.FeatureRequestMode

--- a/samples/edit-feature-attachments/src/main/java/com/esri/arcgismaps/sample/editfeatureattachments/MainActivity.kt
+++ b/samples/edit-feature-attachments/src/main/java/com/esri/arcgismaps/sample/editfeatureattachments/MainActivity.kt
@@ -98,9 +98,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         lifecycle.addObserver(mapView)
 
         // create the feature layer using the service feature table

--- a/samples/edit-features-using-feature-forms/build.gradle.kts
+++ b/samples/edit-features-using-feature-forms/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.editfeaturesusingfeatureforms"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/edit-features-with-feature-linked-annotation/build.gradle.kts
+++ b/samples/edit-features-with-feature-linked-annotation/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.editfeatureswithfeaturelinkedannotation"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/edit-features-with-feature-linked-annotation/src/main/java/com/esri/arcgismaps/sample/editfeatureswithfeaturelinkedannotation/MainActivity.kt
+++ b/samples/edit-features-with-feature-linked-annotation/src/main/java/com/esri/arcgismaps/sample/editfeatureswithfeaturelinkedannotation/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/edit-features-with-feature-linked-annotation/src/main/java/com/esri/arcgismaps/sample/editfeatureswithfeaturelinkedannotation/MainActivity.kt
+++ b/samples/edit-features-with-feature-linked-annotation/src/main/java/com/esri/arcgismaps/sample/editfeatureswithfeaturelinkedannotation/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.editfeatureswithfeaturelinkedannotation.screens.EditFeaturesWithFeatureLinkedAnnotationScreen
 

--- a/samples/edit-geometries-with-programmatic-reticle-tool/build.gradle.kts
+++ b/samples/edit-geometries-with-programmatic-reticle-tool/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.editgeometrieswithprogrammaticreticletool"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/edit-geometries-with-programmatic-reticle-tool/src/main/java/com/esri/arcgismaps/sample/editgeometrieswithprogrammaticreticletool/MainActivity.kt
+++ b/samples/edit-geometries-with-programmatic-reticle-tool/src/main/java/com/esri/arcgismaps/sample/editgeometrieswithprogrammaticreticletool/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.editgeometrieswithprogrammaticreticletool.screens.EditGeometriesWithProgrammaticReticleToolScreen
 

--- a/samples/edit-geometries-with-programmatic-reticle-tool/src/main/java/com/esri/arcgismaps/sample/editgeometrieswithprogrammaticreticletool/MainActivity.kt
+++ b/samples/edit-geometries-with-programmatic-reticle-tool/src/main/java/com/esri/arcgismaps/sample/editgeometrieswithprogrammaticreticletool/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/filter-building-scene-layer/build.gradle.kts
+++ b/samples/filter-building-scene-layer/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.filterbuildingscenelayer"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/filter-building-scene-layer/src/main/java/com/esri/arcgismaps/sample/filterbuildingscenelayer/MainActivity.kt
+++ b/samples/filter-building-scene-layer/src/main/java/com/esri/arcgismaps/sample/filterbuildingscenelayer/MainActivity.kt
@@ -22,7 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
 import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.filterbuildingscenelayer.screens.FilterBuildingSceneLayerScreen
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme

--- a/samples/filter-building-scene-layer/src/main/java/com/esri/arcgismaps/sample/filterbuildingscenelayer/MainActivity.kt
+++ b/samples/filter-building-scene-layer/src/main/java/com/esri/arcgismaps/sample/filterbuildingscenelayer/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         ArcGISEnvironment.applicationContext = this
 
         setContent {

--- a/samples/filter-features-in-scene/build.gradle.kts
+++ b/samples/filter-features-in-scene/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.filterfeaturesinscene"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/filter-features-in-scene/src/main/java/com/esri/arcgismaps/sample/filterfeaturesinscene/MainActivity.kt
+++ b/samples/filter-features-in-scene/src/main/java/com/esri/arcgismaps/sample/filterfeaturesinscene/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.filterfeaturesinscene.screens.FilterFeaturesInSceneScreen
 

--- a/samples/filter-features-in-scene/src/main/java/com/esri/arcgismaps/sample/filterfeaturesinscene/MainActivity.kt
+++ b/samples/filter-features-in-scene/src/main/java/com/esri/arcgismaps/sample/filterfeaturesinscene/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/find-address-with-reverse-geocode/build.gradle.kts
+++ b/samples/find-address-with-reverse-geocode/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/find-address-with-reverse-geocode/src/main/java/com/esri/arcgismaps/sample/findaddresswithreversegeocode/MainActivity.kt
+++ b/samples/find-address-with-reverse-geocode/src/main/java/com/esri/arcgismaps/sample/findaddresswithreversegeocode/MainActivity.kt
@@ -78,9 +78,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         lifecycle.addObserver(mapView)
 
         mapView.apply {

--- a/samples/find-address-with-reverse-geocode/src/main/java/com/esri/arcgismaps/sample/findaddresswithreversegeocode/MainActivity.kt
+++ b/samples/find-address-with-reverse-geocode/src/main/java/com/esri/arcgismaps/sample/findaddresswithreversegeocode/MainActivity.kt
@@ -23,8 +23,6 @@ import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.geometry.GeometryEngine
 import com.arcgismaps.geometry.Point
 import com.arcgismaps.mapping.ArcGISMap

--- a/samples/find-closest-facility-from-point/build.gradle.kts
+++ b/samples/find-closest-facility-from-point/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.findclosestfacilityfrompoint"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/find-closest-facility-from-point/src/main/java/com/esri/arcgismaps/sample/findclosestfacilityfrompoint/MainActivity.kt
+++ b/samples/find-closest-facility-from-point/src/main/java/com/esri/arcgismaps/sample/findclosestfacilityfrompoint/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/find-closest-facility-from-point/src/main/java/com/esri/arcgismaps/sample/findclosestfacilityfrompoint/MainActivity.kt
+++ b/samples/find-closest-facility-from-point/src/main/java/com/esri/arcgismaps/sample/findclosestfacilityfrompoint/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.findclosestfacilityfrompoint.screens.MainScreen
 

--- a/samples/find-nearest-vertex/build.gradle.kts
+++ b/samples/find-nearest-vertex/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.findnearestvertex"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/find-nearest-vertex/src/main/java/com/esri/arcgismaps/sample/findnearestvertex/MainActivity.kt
+++ b/samples/find-nearest-vertex/src/main/java/com/esri/arcgismaps/sample/findnearestvertex/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/find-nearest-vertex/src/main/java/com/esri/arcgismaps/sample/findnearestvertex/MainActivity.kt
+++ b/samples/find-nearest-vertex/src/main/java/com/esri/arcgismaps/sample/findnearestvertex/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.findnearestvertex.screens.FindNearestVertexScreen
 

--- a/samples/find-route-around-barriers/build.gradle.kts
+++ b/samples/find-route-around-barriers/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/find-route-around-barriers/src/main/java/com/esri/arcgismaps/sample/findroutearoundbarriers/MainActivity.kt
+++ b/samples/find-route-around-barriers/src/main/java/com/esri/arcgismaps/sample/findroutearoundbarriers/MainActivity.kt
@@ -161,9 +161,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         // some parts of the API require an Android Context to properly interact with Android system
         // features, such as LocationProvider and application resources
         ArcGISEnvironment.applicationContext = applicationContext

--- a/samples/find-route-around-barriers/src/main/java/com/esri/arcgismaps/sample/findroutearoundbarriers/MainActivity.kt
+++ b/samples/find-route-around-barriers/src/main/java/com/esri/arcgismaps/sample/findroutearoundbarriers/MainActivity.kt
@@ -32,7 +32,6 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.ContextCompat
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
-import com.arcgismaps.ApiKey
 import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.Color
 import com.arcgismaps.geometry.GeometryEngine

--- a/samples/find-route-in-transport-network/build.gradle.kts
+++ b/samples/find-route-in-transport-network/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/find-route-in-transport-network/src/main/java/com/esri/arcgismaps/sample/findrouteintransportnetwork/MainActivity.kt
+++ b/samples/find-route-in-transport-network/src/main/java/com/esri/arcgismaps/sample/findrouteintransportnetwork/MainActivity.kt
@@ -23,7 +23,6 @@ import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
-import com.arcgismaps.ApiKey
 import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.Color
 import com.arcgismaps.geometry.Envelope

--- a/samples/find-route-in-transport-network/src/main/java/com/esri/arcgismaps/sample/findrouteintransportnetwork/MainActivity.kt
+++ b/samples/find-route-in-transport-network/src/main/java/com/esri/arcgismaps/sample/findrouteintransportnetwork/MainActivity.kt
@@ -97,9 +97,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         // some parts of the API require an Android Context to properly interact with Android system
         // features, such as LocationProvider and application resources
         ArcGISEnvironment.applicationContext = applicationContext

--- a/samples/find-route/build.gradle.kts
+++ b/samples/find-route/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.findroute"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/find-route/src/main/java/com/esri/arcgismaps/sample/findroute/MainActivity.kt
+++ b/samples/find-route/src/main/java/com/esri/arcgismaps/sample/findroute/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.findroute.screens.FindRouteScreen
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 

--- a/samples/find-route/src/main/java/com/esri/arcgismaps/sample/findroute/MainActivity.kt
+++ b/samples/find-route/src/main/java/com/esri/arcgismaps/sample/findroute/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/generate-geodatabase-replica-from-feature-service/build.gradle.kts
+++ b/samples/generate-geodatabase-replica-from-feature-service/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.generategeodatabasereplicafromfeatureservice"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/generate-geodatabase-replica-from-feature-service/src/main/java/com/esri/arcgismaps/sample/generategeodatabasereplicafromfeatureservice/MainActivity.kt
+++ b/samples/generate-geodatabase-replica-from-feature-service/src/main/java/com/esri/arcgismaps/sample/generategeodatabasereplicafromfeatureservice/MainActivity.kt
@@ -24,19 +24,13 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
-import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.generategeodatabasereplicafromfeatureservice.screens.GenerateGeodatabaseReplicaFromFeatureServiceScreen
-import com.esri.arcgismaps.sample.sampleslib.BuildConfig
+import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 
 class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/generate-offline-map-using-android-jetpack-workmanager/build.gradle.kts
+++ b/samples/generate-offline-map-using-android-jetpack-workmanager/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/generate-offline-map-using-android-jetpack-workmanager/src/main/java/com/esri/arcgismaps/sample/generateofflinemapusingandroidjetpackworkmanager/MainActivity.kt
+++ b/samples/generate-offline-map-using-android-jetpack-workmanager/src/main/java/com/esri/arcgismaps/sample/generateofflinemapusingandroidjetpackworkmanager/MainActivity.kt
@@ -35,8 +35,6 @@ import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.workDataOf
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.Color
 import com.arcgismaps.geometry.Envelope
 import com.arcgismaps.geometry.Geometry

--- a/samples/generate-offline-map-using-android-jetpack-workmanager/src/main/java/com/esri/arcgismaps/sample/generateofflinemapusingandroidjetpackworkmanager/MainActivity.kt
+++ b/samples/generate-offline-map-using-android-jetpack-workmanager/src/main/java/com/esri/arcgismaps/sample/generateofflinemapusingandroidjetpackworkmanager/MainActivity.kt
@@ -125,9 +125,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
         // request notifications permission
         requestNotificationPermission()
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         lifecycle.addObserver(mapView)
 
         // set up the portal item to take offline

--- a/samples/generate-offline-map-with-custom-parameters/build.gradle.kts
+++ b/samples/generate-offline-map-with-custom-parameters/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.generateofflinemapwithcustomparameters"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/generate-offline-map-with-custom-parameters/src/main/java/com/esri/arcgismaps/sample/generateofflinemapwithcustomparameters/MainActivity.kt
+++ b/samples/generate-offline-map-with-custom-parameters/src/main/java/com/esri/arcgismaps/sample/generateofflinemapwithcustomparameters/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.generateofflinemapwithcustomparameters.screens.GenerateOfflineMapWithCustomParametersScreen
 

--- a/samples/generate-offline-map-with-custom-parameters/src/main/java/com/esri/arcgismaps/sample/generateofflinemapwithcustomparameters/MainActivity.kt
+++ b/samples/generate-offline-map-with-custom-parameters/src/main/java/com/esri/arcgismaps/sample/generateofflinemapwithcustomparameters/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/generate-offline-map/build.gradle.kts
+++ b/samples/generate-offline-map/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.generateofflinemap"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/generate-offline-map/src/main/java/com/esri/arcgismaps/sample/generateofflinemap/MainActivity.kt
+++ b/samples/generate-offline-map/src/main/java/com/esri/arcgismaps/sample/generateofflinemap/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.generateofflinemap.screens.MainScreen
 

--- a/samples/generate-offline-map/src/main/java/com/esri/arcgismaps/sample/generateofflinemap/MainActivity.kt
+++ b/samples/generate-offline-map/src/main/java/com/esri/arcgismaps/sample/generateofflinemap/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/geocode-offline/build.gradle.kts
+++ b/samples/geocode-offline/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/geocode-offline/src/main/java/com/esri/arcgismaps/sample/geocodeoffline/MainActivity.kt
+++ b/samples/geocode-offline/src/main/java/com/esri/arcgismaps/sample/geocodeoffline/MainActivity.kt
@@ -30,8 +30,6 @@ import androidx.core.content.ContextCompat
 import androidx.cursoradapter.widget.SimpleCursorAdapter
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.geometry.GeometryEngine
 import com.arcgismaps.geometry.Point
 import com.arcgismaps.mapping.ArcGISMap

--- a/samples/geocode-offline/src/main/java/com/esri/arcgismaps/sample/geocodeoffline/MainActivity.kt
+++ b/samples/geocode-offline/src/main/java/com/esri/arcgismaps/sample/geocodeoffline/MainActivity.kt
@@ -97,9 +97,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         lifecycle.addObserver(mapView)
 
         // load the tile cache from local storage

--- a/samples/get-elevation-at-point-on-surface/build.gradle.kts
+++ b/samples/get-elevation-at-point-on-surface/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.getelevationatpointonsurface"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/get-elevation-at-point-on-surface/src/main/java/com/esri/arcgismaps/sample/getelevationatpointonsurface/MainActivity.kt
+++ b/samples/get-elevation-at-point-on-surface/src/main/java/com/esri/arcgismaps/sample/getelevationatpointonsurface/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.getelevationatpointonsurface.screens.GetElevationAtPointOnSurfaceScreen
 

--- a/samples/get-elevation-at-point-on-surface/src/main/java/com/esri/arcgismaps/sample/getelevationatpointonsurface/MainActivity.kt
+++ b/samples/get-elevation-at-point-on-surface/src/main/java/com/esri/arcgismaps/sample/getelevationatpointonsurface/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/identify-graphics/build.gradle.kts
+++ b/samples/identify-graphics/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.identifygraphics"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/identify-graphics/src/main/java/com/esri/arcgismaps/sample/identifygraphics/MainActivity.kt
+++ b/samples/identify-graphics/src/main/java/com/esri/arcgismaps/sample/identifygraphics/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/identify-graphics/src/main/java/com/esri/arcgismaps/sample/identifygraphics/MainActivity.kt
+++ b/samples/identify-graphics/src/main/java/com/esri/arcgismaps/sample/identifygraphics/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.identifygraphics.screens.IdentifyGraphicsScreen
 

--- a/samples/identify-layer-features/build.gradle.kts
+++ b/samples/identify-layer-features/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.identifylayerfeatures"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/identify-layer-features/src/main/java/com/esri/arcgismaps/sample/identifylayerfeatures/MainActivity.kt
+++ b/samples/identify-layer-features/src/main/java/com/esri/arcgismaps/sample/identifylayerfeatures/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.identifylayerfeatures.screens.MainScreen
 

--- a/samples/identify-layer-features/src/main/java/com/esri/arcgismaps/sample/identifylayerfeatures/MainActivity.kt
+++ b/samples/identify-layer-features/src/main/java/com/esri/arcgismaps/sample/identifylayerfeatures/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/manage-features/build.gradle.kts
+++ b/samples/manage-features/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.managefeatures"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/manage-features/src/main/java/com/esri/arcgismaps/sample/managefeatures/MainActivity.kt
+++ b/samples/manage-features/src/main/java/com/esri/arcgismaps/sample/managefeatures/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.managefeatures.screens.ManageFeaturesScreen
 

--- a/samples/manage-features/src/main/java/com/esri/arcgismaps/sample/managefeatures/MainActivity.kt
+++ b/samples/manage-features/src/main/java/com/esri/arcgismaps/sample/managefeatures/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/manage-operational-layers/build.gradle.kts
+++ b/samples/manage-operational-layers/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.manageoperationallayers"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/manage-operational-layers/src/main/java/com/esri/arcgismaps/sample/manageoperationallayers/MainActivity.kt
+++ b/samples/manage-operational-layers/src/main/java/com/esri/arcgismaps/sample/manageoperationallayers/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.manageoperationallayers.screens.MainScreen
 

--- a/samples/manage-operational-layers/src/main/java/com/esri/arcgismaps/sample/manageoperationallayers/MainActivity.kt
+++ b/samples/manage-operational-layers/src/main/java/com/esri/arcgismaps/sample/manageoperationallayers/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/match-viewpoint-of-geo-views/build.gradle.kts
+++ b/samples/match-viewpoint-of-geo-views/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.matchviewpointofgeoviews"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/match-viewpoint-of-geo-views/src/main/java/com/esri/arcgismaps/sample/matchviewpointofgeoviews/MainActivity.kt
+++ b/samples/match-viewpoint-of-geo-views/src/main/java/com/esri/arcgismaps/sample/matchviewpointofgeoviews/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/match-viewpoint-of-geo-views/src/main/java/com/esri/arcgismaps/sample/matchviewpointofgeoviews/MainActivity.kt
+++ b/samples/match-viewpoint-of-geo-views/src/main/java/com/esri/arcgismaps/sample/matchviewpointofgeoviews/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.matchviewpointofgeoviews.screens.MatchViewpointOfGeoViewsScreen
 

--- a/samples/monitor-changes-to-draw-status/build.gradle.kts
+++ b/samples/monitor-changes-to-draw-status/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.monitorchangestodrawstatus"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/monitor-changes-to-draw-status/src/main/java/com/esri/arcgismaps/sample/monitorchangestodrawstatus/MainActivity.kt
+++ b/samples/monitor-changes-to-draw-status/src/main/java/com/esri/arcgismaps/sample/monitorchangestodrawstatus/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/monitor-changes-to-draw-status/src/main/java/com/esri/arcgismaps/sample/monitorchangestodrawstatus/MainActivity.kt
+++ b/samples/monitor-changes-to-draw-status/src/main/java/com/esri/arcgismaps/sample/monitorchangestodrawstatus/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.monitorchangestodrawstatus.screens.MonitorDrawStatusScreen
 

--- a/samples/monitor-changes-to-layer-view-state/build.gradle.kts
+++ b/samples/monitor-changes-to-layer-view-state/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.monitorchangestolayerviewstate"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/monitor-changes-to-layer-view-state/src/main/java/com/esri/arcgismaps/sample/monitorchangestolayerviewstate/MainActivity.kt
+++ b/samples/monitor-changes-to-layer-view-state/src/main/java/com/esri/arcgismaps/sample/monitorchangestolayerviewstate/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/monitor-changes-to-layer-view-state/src/main/java/com/esri/arcgismaps/sample/monitorchangestolayerviewstate/MainActivity.kt
+++ b/samples/monitor-changes-to-layer-view-state/src/main/java/com/esri/arcgismaps/sample/monitorchangestolayerviewstate/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.monitorchangestolayerviewstate.screens.MonitorChangesToLayerViewStateScreen
 

--- a/samples/monitor-changes-to-map-load-status/build.gradle.kts
+++ b/samples/monitor-changes-to-map-load-status/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.monitorchangestomaploadstatus"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/monitor-changes-to-map-load-status/src/main/java/com/esri/arcgismaps/sample/monitorchangestomaploadstatus/MainActivity.kt
+++ b/samples/monitor-changes-to-map-load-status/src/main/java/com/esri/arcgismaps/sample/monitorchangestomaploadstatus/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         setContent {
             SampleAppTheme {
                 MonitorChangesToMapLoadStatusApp()

--- a/samples/monitor-changes-to-map-load-status/src/main/java/com/esri/arcgismaps/sample/monitorchangestomaploadstatus/MainActivity.kt
+++ b/samples/monitor-changes-to-map-load-status/src/main/java/com/esri/arcgismaps/sample/monitorchangestomaploadstatus/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.monitorchangestomaploadstatus.screens.MonitorChangesToMapLoadStatusScreen
 

--- a/samples/navigate-route-with-rerouting/build.gradle.kts
+++ b/samples/navigate-route-with-rerouting/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.navigateroutewithrerouting"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/navigate-route-with-rerouting/src/main/java/com/esri/arcgismaps/sample/navigateroutewithrerouting/MainActivity.kt
+++ b/samples/navigate-route-with-rerouting/src/main/java/com/esri/arcgismaps/sample/navigateroutewithrerouting/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.navigateroutewithrerouting.screens.NavigateRouteWithReroutingScreen
 

--- a/samples/navigate-route-with-rerouting/src/main/java/com/esri/arcgismaps/sample/navigateroutewithrerouting/MainActivity.kt
+++ b/samples/navigate-route-with-rerouting/src/main/java/com/esri/arcgismaps/sample/navigateroutewithrerouting/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/navigate-route/build.gradle.kts
+++ b/samples/navigate-route/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.navigateroute"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/navigate-route/src/main/java/com/esri/arcgismaps/sample/navigateroute/MainActivity.kt
+++ b/samples/navigate-route/src/main/java/com/esri/arcgismaps/sample/navigateroute/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.navigateroute.screens.NavigateRouteScreen
 

--- a/samples/navigate-route/src/main/java/com/esri/arcgismaps/sample/navigateroute/MainActivity.kt
+++ b/samples/navigate-route/src/main/java/com/esri/arcgismaps/sample/navigateroute/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/play-kml-tour/build.gradle.kts
+++ b/samples/play-kml-tour/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.playkmltour"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/play-kml-tour/src/main/java/com/esri/arcgismaps/sample/playkmltour/MainActivity.kt
+++ b/samples/play-kml-tour/src/main/java/com/esri/arcgismaps/sample/playkmltour/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.playkmltour.screens.PlayKmlTourScreen
 

--- a/samples/play-kml-tour/src/main/java/com/esri/arcgismaps/sample/playkmltour/MainActivity.kt
+++ b/samples/play-kml-tour/src/main/java/com/esri/arcgismaps/sample/playkmltour/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/project-geometry/build.gradle.kts
+++ b/samples/project-geometry/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.projectgeometry"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/project-geometry/src/main/java/com/esri/arcgismaps/sample/projectgeometry/MainActivity.kt
+++ b/samples/project-geometry/src/main/java/com/esri/arcgismaps/sample/projectgeometry/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/project-geometry/src/main/java/com/esri/arcgismaps/sample/projectgeometry/MainActivity.kt
+++ b/samples/project-geometry/src/main/java/com/esri/arcgismaps/sample/projectgeometry/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.projectgeometry.screens.ProjectGeometryScreen
 

--- a/samples/query-dynamic-entities/build.gradle.kts
+++ b/samples/query-dynamic-entities/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.querydynamicentities"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/query-dynamic-entities/src/main/java/com/esri/arcgismaps/sample/querydynamicentities/MainActivity.kt
+++ b/samples/query-dynamic-entities/src/main/java/com/esri/arcgismaps/sample/querydynamicentities/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/query-dynamic-entities/src/main/java/com/esri/arcgismaps/sample/querydynamicentities/MainActivity.kt
+++ b/samples/query-dynamic-entities/src/main/java/com/esri/arcgismaps/sample/querydynamicentities/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.querydynamicentities.screens.QueryDynamicEntitiesScreen
 

--- a/samples/query-feature-table/build.gradle.kts
+++ b/samples/query-feature-table/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.queryfeaturetable"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/query-feature-table/src/main/java/com/esri/arcgismaps/sample/queryfeaturetable/MainActivity.kt
+++ b/samples/query-feature-table/src/main/java/com/esri/arcgismaps/sample/queryfeaturetable/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.queryfeaturetable.screens.MainScreen
 

--- a/samples/query-feature-table/src/main/java/com/esri/arcgismaps/sample/queryfeaturetable/MainActivity.kt
+++ b/samples/query-feature-table/src/main/java/com/esri/arcgismaps/sample/queryfeaturetable/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/query-features-with-arcade-expression/build.gradle.kts
+++ b/samples/query-features-with-arcade-expression/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.queryfeatureswitharcadeexpression"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/query-features-with-arcade-expression/src/main/java/com/esri/arcgismaps/sample/queryfeatureswitharcadeexpression/MainActivity.kt
+++ b/samples/query-features-with-arcade-expression/src/main/java/com/esri/arcgismaps/sample/queryfeatureswitharcadeexpression/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.queryfeatureswitharcadeexpression.screens.QueryFeaturesWithArcadeExpressionScreen
 

--- a/samples/query-features-with-arcade-expression/src/main/java/com/esri/arcgismaps/sample/queryfeatureswitharcadeexpression/MainActivity.kt
+++ b/samples/query-features-with-arcade-expression/src/main/java/com/esri/arcgismaps/sample/queryfeatureswitharcadeexpression/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/render-multilayer-symbols/build.gradle.kts
+++ b/samples/render-multilayer-symbols/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/render-multilayer-symbols/src/main/java/com/esri/arcgismaps/sample/rendermultilayersymbols/MainActivity.kt
+++ b/samples/render-multilayer-symbols/src/main/java/com/esri/arcgismaps/sample/rendermultilayersymbols/MainActivity.kt
@@ -78,9 +78,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         lifecycle.addObserver(mapView)
 
         mapView.apply {

--- a/samples/render-multilayer-symbols/src/main/java/com/esri/arcgismaps/sample/rendermultilayersymbols/MainActivity.kt
+++ b/samples/render-multilayer-symbols/src/main/java/com/esri/arcgismaps/sample/rendermultilayersymbols/MainActivity.kt
@@ -23,8 +23,6 @@ import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.core.graphics.drawable.toDrawable
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.Color
 import com.arcgismaps.geometry.Envelope
 import com.arcgismaps.geometry.Geometry

--- a/samples/search-with-geocode/build.gradle.kts
+++ b/samples/search-with-geocode/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/search-with-geocode/src/main/java/com/esri/arcgismaps/sample/searchwithgeocode/MainActivity.kt
+++ b/samples/search-with-geocode/src/main/java/com/esri/arcgismaps/sample/searchwithgeocode/MainActivity.kt
@@ -95,9 +95,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         lifecycle.addObserver(mapView)
 
         mapView.apply {

--- a/samples/search-with-geocode/src/main/java/com/esri/arcgismaps/sample/searchwithgeocode/MainActivity.kt
+++ b/samples/search-with-geocode/src/main/java/com/esri/arcgismaps/sample/searchwithgeocode/MainActivity.kt
@@ -33,8 +33,6 @@ import androidx.core.text.bold
 import androidx.cursoradapter.widget.SimpleCursorAdapter
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.geometry.Geometry
 import com.arcgismaps.mapping.ArcGISMap
 import com.arcgismaps.mapping.BasemapStyle

--- a/samples/select-features-in-feature-layer/build.gradle.kts
+++ b/samples/select-features-in-feature-layer/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/select-features-in-feature-layer/src/main/java/com/esri/arcgismaps/sample/selectfeaturesinfeaturelayer/MainActivity.kt
+++ b/samples/select-features-in-feature-layer/src/main/java/com/esri/arcgismaps/sample/selectfeaturesinfeaturelayer/MainActivity.kt
@@ -57,9 +57,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         lifecycle.addObserver(mapView)
 
         // create a map with the streets base map type

--- a/samples/select-features-in-feature-layer/src/main/java/com/esri/arcgismaps/sample/selectfeaturesinfeaturelayer/MainActivity.kt
+++ b/samples/select-features-in-feature-layer/src/main/java/com/esri/arcgismaps/sample/selectfeaturesinfeaturelayer/MainActivity.kt
@@ -20,8 +20,6 @@ import android.os.Bundle
 import android.util.Log
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.Color
 import com.arcgismaps.data.Feature
 import com.arcgismaps.data.ServiceFeatureTable

--- a/samples/set-atmosphere-effect-in-scene/build.gradle.kts
+++ b/samples/set-atmosphere-effect-in-scene/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.setatmosphereeffectinscene"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/set-atmosphere-effect-in-scene/src/main/java/com/esri/arcgismaps/sample/setatmosphereeffectinscene/MainActivity.kt
+++ b/samples/set-atmosphere-effect-in-scene/src/main/java/com/esri/arcgismaps/sample/setatmosphereeffectinscene/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.setatmosphereeffectinscene.screens.SetAtmosphereEffectInSceneScreen
 

--- a/samples/set-atmosphere-effect-in-scene/src/main/java/com/esri/arcgismaps/sample/setatmosphereeffectinscene/MainActivity.kt
+++ b/samples/set-atmosphere-effect-in-scene/src/main/java/com/esri/arcgismaps/sample/setatmosphereeffectinscene/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/set-basemap/build.gradle.kts
+++ b/samples/set-basemap/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.setbasemap"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/set-basemap/src/main/java/com/esri/arcgismaps/sample/setbasemap/MainActivity.kt
+++ b/samples/set-basemap/src/main/java/com/esri/arcgismaps/sample/setbasemap/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/set-basemap/src/main/java/com/esri/arcgismaps/sample/setbasemap/MainActivity.kt
+++ b/samples/set-basemap/src/main/java/com/esri/arcgismaps/sample/setbasemap/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.setbasemap.screens.SetBasemapScreen
 

--- a/samples/set-feature-layer-rendering-mode-on-map/build.gradle.kts
+++ b/samples/set-feature-layer-rendering-mode-on-map/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.setfeaturelayerrenderingmodeonmap"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/set-feature-layer-rendering-mode-on-map/src/main/java/com/esri/arcgismaps/sample/setfeaturelayerrenderingmodeonmap/MainActivity.kt
+++ b/samples/set-feature-layer-rendering-mode-on-map/src/main/java/com/esri/arcgismaps/sample/setfeaturelayerrenderingmodeonmap/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/set-feature-layer-rendering-mode-on-map/src/main/java/com/esri/arcgismaps/sample/setfeaturelayerrenderingmodeonmap/MainActivity.kt
+++ b/samples/set-feature-layer-rendering-mode-on-map/src/main/java/com/esri/arcgismaps/sample/setfeaturelayerrenderingmodeonmap/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.setfeaturelayerrenderingmodeonmap.screens.SetFeatureLayerRenderingModeOnMapScreen
 

--- a/samples/set-feature-layer-rendering-mode-on-scene/build.gradle.kts
+++ b/samples/set-feature-layer-rendering-mode-on-scene/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.setfeaturelayerrenderingmodeonscene"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/set-feature-layer-rendering-mode-on-scene/src/main/java/com/esri/arcgismaps/sample/setfeaturelayerrenderingmodeonscene/MainActivity.kt
+++ b/samples/set-feature-layer-rendering-mode-on-scene/src/main/java/com/esri/arcgismaps/sample/setfeaturelayerrenderingmodeonscene/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/set-feature-layer-rendering-mode-on-scene/src/main/java/com/esri/arcgismaps/sample/setfeaturelayerrenderingmodeonscene/MainActivity.kt
+++ b/samples/set-feature-layer-rendering-mode-on-scene/src/main/java/com/esri/arcgismaps/sample/setfeaturelayerrenderingmodeonscene/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.setfeaturelayerrenderingmodeonscene.screens.SetFeatureLayerRenderingModeOnSceneScreen
 

--- a/samples/set-feature-request-mode/build.gradle.kts
+++ b/samples/set-feature-request-mode/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.setfeaturerequestmode"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/set-feature-request-mode/src/main/java/com/esri/arcgismaps/sample/setfeaturerequestmode/MainActivity.kt
+++ b/samples/set-feature-request-mode/src/main/java/com/esri/arcgismaps/sample/setfeaturerequestmode/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.setfeaturerequestmode.screens.SetFeatureRequestModeScreen
 

--- a/samples/set-feature-request-mode/src/main/java/com/esri/arcgismaps/sample/setfeaturerequestmode/MainActivity.kt
+++ b/samples/set-feature-request-mode/src/main/java/com/esri/arcgismaps/sample/setfeaturerequestmode/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/set-initial-map-location/build.gradle.kts
+++ b/samples/set-initial-map-location/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.setinitialmaplocation"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/set-initial-map-location/src/main/java/com/esri/arcgismaps/sample/setinitialmaplocation/MainActivity.kt
+++ b/samples/set-initial-map-location/src/main/java/com/esri/arcgismaps/sample/setinitialmaplocation/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.setinitialmaplocation.screens.SetInitialMapLocationScreen
 

--- a/samples/set-initial-map-location/src/main/java/com/esri/arcgismaps/sample/setinitialmaplocation/MainActivity.kt
+++ b/samples/set-initial-map-location/src/main/java/com/esri/arcgismaps/sample/setinitialmaplocation/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/set-initial-viewpoint/build.gradle.kts
+++ b/samples/set-initial-viewpoint/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.setinitialviewpoint"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/set-initial-viewpoint/src/main/java/com/esri/arcgismaps/sample/setinitialviewpoint/MainActivity.kt
+++ b/samples/set-initial-viewpoint/src/main/java/com/esri/arcgismaps/sample/setinitialviewpoint/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/set-initial-viewpoint/src/main/java/com/esri/arcgismaps/sample/setinitialviewpoint/MainActivity.kt
+++ b/samples/set-initial-viewpoint/src/main/java/com/esri/arcgismaps/sample/setinitialviewpoint/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.setinitialviewpoint.screens.SetInitialViewpointScreen
 

--- a/samples/set-max-extent/build.gradle.kts
+++ b/samples/set-max-extent/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.setmaxextent"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/set-max-extent/src/main/java/com/esri/arcgismaps/sample/setmaxextent/MainActivity.kt
+++ b/samples/set-max-extent/src/main/java/com/esri/arcgismaps/sample/setmaxextent/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.setmaxextent.screens.SetMaxExtentScreen
 

--- a/samples/set-max-extent/src/main/java/com/esri/arcgismaps/sample/setmaxextent/MainActivity.kt
+++ b/samples/set-max-extent/src/main/java/com/esri/arcgismaps/sample/setmaxextent/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/set-min-and-max-scale/build.gradle.kts
+++ b/samples/set-min-and-max-scale/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.setminandmaxscale"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/set-min-and-max-scale/src/main/java/com/esri/arcgismaps/sample/setminandmaxscale/MainActivity.kt
+++ b/samples/set-min-and-max-scale/src/main/java/com/esri/arcgismaps/sample/setminandmaxscale/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/set-min-and-max-scale/src/main/java/com/esri/arcgismaps/sample/setminandmaxscale/MainActivity.kt
+++ b/samples/set-min-and-max-scale/src/main/java/com/esri/arcgismaps/sample/setminandmaxscale/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.setminandmaxscale.screens.SetMinAndMaxScaleScreen
 

--- a/samples/set-reference-scale/build.gradle.kts
+++ b/samples/set-reference-scale/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.setreferencescale"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/set-reference-scale/src/main/java/com/esri/arcgismaps/sample/setreferencescale/MainActivity.kt
+++ b/samples/set-reference-scale/src/main/java/com/esri/arcgismaps/sample/setreferencescale/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/set-reference-scale/src/main/java/com/esri/arcgismaps/sample/setreferencescale/MainActivity.kt
+++ b/samples/set-reference-scale/src/main/java/com/esri/arcgismaps/sample/setreferencescale/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.setreferencescale.screens.SetReferenceScaleScreen
 

--- a/samples/set-spatial-reference/build.gradle.kts
+++ b/samples/set-spatial-reference/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.setspatialreference"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/set-spatial-reference/src/main/java/com/esri/arcgismaps/sample/setspatialreference/MainActivity.kt
+++ b/samples/set-spatial-reference/src/main/java/com/esri/arcgismaps/sample/setspatialreference/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/set-spatial-reference/src/main/java/com/esri/arcgismaps/sample/setspatialreference/MainActivity.kt
+++ b/samples/set-spatial-reference/src/main/java/com/esri/arcgismaps/sample/setspatialreference/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.setspatialreference.screens.SetSpatialReferenceScreen
 

--- a/samples/set-surface-navigation-constraint/build.gradle.kts
+++ b/samples/set-surface-navigation-constraint/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.setsurfacenavigationconstraint"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/set-surface-navigation-constraint/src/main/java/com/esri/arcgismaps/sample/setsurfacenavigationconstraint/MainActivity.kt
+++ b/samples/set-surface-navigation-constraint/src/main/java/com/esri/arcgismaps/sample/setsurfacenavigationconstraint/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/set-surface-navigation-constraint/src/main/java/com/esri/arcgismaps/sample/setsurfacenavigationconstraint/MainActivity.kt
+++ b/samples/set-surface-navigation-constraint/src/main/java/com/esri/arcgismaps/sample/setsurfacenavigationconstraint/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.setsurfacenavigationconstraint.screens.SetSurfaceNavigationConstraintScreen
 

--- a/samples/set-surface-placement-mode/build.gradle.kts
+++ b/samples/set-surface-placement-mode/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.setsurfaceplacementmode"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/set-surface-placement-mode/src/main/java/com/esri/arcgismaps/sample/setsurfaceplacementmode/MainActivity.kt
+++ b/samples/set-surface-placement-mode/src/main/java/com/esri/arcgismaps/sample/setsurfaceplacementmode/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/set-surface-placement-mode/src/main/java/com/esri/arcgismaps/sample/setsurfaceplacementmode/MainActivity.kt
+++ b/samples/set-surface-placement-mode/src/main/java/com/esri/arcgismaps/sample/setsurfaceplacementmode/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.setsurfaceplacementmode.screens.SetSurfacePlacementModeScreen
 

--- a/samples/set-up-location-driven-geotriggers/build.gradle.kts
+++ b/samples/set-up-location-driven-geotriggers/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/set-up-location-driven-geotriggers/src/main/java/com/esri/arcgismaps/sample/setuplocationdrivengeotriggers/MainActivity.kt
+++ b/samples/set-up-location-driven-geotriggers/src/main/java/com/esri/arcgismaps/sample/setuplocationdrivengeotriggers/MainActivity.kt
@@ -118,9 +118,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         lifecycle.addObserver(mapView)
 
         val portal = Portal("https://www.arcgis.com")

--- a/samples/set-up-location-driven-geotriggers/src/main/java/com/esri/arcgismaps/sample/setuplocationdrivengeotriggers/MainActivity.kt
+++ b/samples/set-up-location-driven-geotriggers/src/main/java/com/esri/arcgismaps/sample/setuplocationdrivengeotriggers/MainActivity.kt
@@ -24,8 +24,6 @@ import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.arcade.ArcadeExpression
 import com.arcgismaps.data.ArcGISFeature
 import com.arcgismaps.data.ServiceFeatureTable

--- a/samples/set-viewpoint-rotation/build.gradle.kts
+++ b/samples/set-viewpoint-rotation/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/set-viewpoint-rotation/src/main/java/com/esri/arcgismaps/sample/setviewpointrotation/MainActivity.kt
+++ b/samples/set-viewpoint-rotation/src/main/java/com/esri/arcgismaps/sample/setviewpointrotation/MainActivity.kt
@@ -20,8 +20,6 @@ import android.os.Bundle
 import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.mapping.ArcGISMap
 import com.arcgismaps.mapping.BasemapStyle
 import com.arcgismaps.mapping.Viewpoint

--- a/samples/set-viewpoint-rotation/src/main/java/com/esri/arcgismaps/sample/setviewpointrotation/MainActivity.kt
+++ b/samples/set-viewpoint-rotation/src/main/java/com/esri/arcgismaps/sample/setviewpointrotation/MainActivity.kt
@@ -33,9 +33,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         // set up data binding for the activity
         val activityMainBinding: SetViewpointRotationActivityMainBinding =

--- a/samples/show-callout/build.gradle.kts
+++ b/samples/show-callout/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.showcallout"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/show-callout/src/main/java/com/esri/arcgismaps/sample/showcallout/MainActivity.kt
+++ b/samples/show-callout/src/main/java/com/esri/arcgismaps/sample/showcallout/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.showcallout.screens.MainScreen
 

--- a/samples/show-callout/src/main/java/com/esri/arcgismaps/sample/showcallout/MainActivity.kt
+++ b/samples/show-callout/src/main/java/com/esri/arcgismaps/sample/showcallout/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/show-coordinates-in-multiple-formats/build.gradle.kts
+++ b/samples/show-coordinates-in-multiple-formats/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.showcoordinatesinmultipleformats"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/show-coordinates-in-multiple-formats/src/main/java/com/esri/arcgismaps/sample/showcoordinatesinmultipleformats/MainActivity.kt
+++ b/samples/show-coordinates-in-multiple-formats/src/main/java/com/esri/arcgismaps/sample/showcoordinatesinmultipleformats/MainActivity.kt
@@ -24,8 +24,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.core.view.WindowCompat
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.showcoordinatesinmultipleformats.screens.MainScreen
 

--- a/samples/show-coordinates-in-multiple-formats/src/main/java/com/esri/arcgismaps/sample/showcoordinatesinmultipleformats/MainActivity.kt
+++ b/samples/show-coordinates-in-multiple-formats/src/main/java/com/esri/arcgismaps/sample/showcoordinatesinmultipleformats/MainActivity.kt
@@ -33,9 +33,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         // remove focus from text fields when keyboard closes
         WindowCompat.setDecorFitsSystemWindows(window, false)
         // set compose content

--- a/samples/show-device-location-using-fused-location-data-source/build.gradle.kts
+++ b/samples/show-device-location-using-fused-location-data-source/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.showdevicelocationusingfusedlocationdatasource"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/show-device-location-using-fused-location-data-source/src/main/java/com/esri/arcgismaps/sample/showdevicelocationusingfusedlocationdatasource/MainActivity.kt
+++ b/samples/show-device-location-using-fused-location-data-source/src/main/java/com/esri/arcgismaps/sample/showdevicelocationusingfusedlocationdatasource/MainActivity.kt
@@ -53,9 +53,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         ArcGISEnvironment.applicationContext = applicationContext
 
         requestLocationPermission()

--- a/samples/show-device-location-using-fused-location-data-source/src/main/java/com/esri/arcgismaps/sample/showdevicelocationusingfusedlocationdatasource/MainActivity.kt
+++ b/samples/show-device-location-using-fused-location-data-source/src/main/java/com/esri/arcgismaps/sample/showdevicelocationusingfusedlocationdatasource/MainActivity.kt
@@ -26,7 +26,6 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
 import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.showdevicelocationusingfusedlocationdatasource.screens.ShowDeviceLocationUsingFusedLocationDataSource

--- a/samples/show-device-location-using-indoor-positioning/build.gradle.kts
+++ b/samples/show-device-location-using-indoor-positioning/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/show-device-location/build.gradle.kts
+++ b/samples/show-device-location/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.showdevicelocation"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/show-device-location/src/main/java/com/esri/arcgismaps/sample/showdevicelocation/MainActivity.kt
+++ b/samples/show-device-location/src/main/java/com/esri/arcgismaps/sample/showdevicelocation/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.showdevicelocation.screens.ShowDeviceLocationScreen
 

--- a/samples/show-device-location/src/main/java/com/esri/arcgismaps/sample/showdevicelocation/MainActivity.kt
+++ b/samples/show-device-location/src/main/java/com/esri/arcgismaps/sample/showdevicelocation/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/show-exploratory-line-of-sight-between-geoelements/build.gradle.kts
+++ b/samples/show-exploratory-line-of-sight-between-geoelements/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.showexploratorylineofsightbetweengeoelements"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/show-exploratory-line-of-sight-between-geoelements/src/main/java/com/esri/arcgismaps/sample/showexploratorylineofsightbetweengeoelements/MainActivity.kt
+++ b/samples/show-exploratory-line-of-sight-between-geoelements/src/main/java/com/esri/arcgismaps/sample/showexploratorylineofsightbetweengeoelements/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.showexploratorylineofsightbetweengeoelements.screens.MainScreen
 

--- a/samples/show-exploratory-line-of-sight-between-geoelements/src/main/java/com/esri/arcgismaps/sample/showexploratorylineofsightbetweengeoelements/MainActivity.kt
+++ b/samples/show-exploratory-line-of-sight-between-geoelements/src/main/java/com/esri/arcgismaps/sample/showexploratorylineofsightbetweengeoelements/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/show-exploratory-viewshed-from-point-in-scene/build.gradle.kts
+++ b/samples/show-exploratory-viewshed-from-point-in-scene/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.showexploratoryviewshedfrompointinscene"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/show-exploratory-viewshed-from-point-in-scene/src/main/java/com/esri/arcgismaps/sample/showexploratoryviewshedfrompointinscene/MainActivity.kt
+++ b/samples/show-exploratory-viewshed-from-point-in-scene/src/main/java/com/esri/arcgismaps/sample/showexploratoryviewshedfrompointinscene/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.showexploratoryviewshedfrompointinscene.screens.MainScreen
 

--- a/samples/show-exploratory-viewshed-from-point-in-scene/src/main/java/com/esri/arcgismaps/sample/showexploratoryviewshedfrompointinscene/MainActivity.kt
+++ b/samples/show-exploratory-viewshed-from-point-in-scene/src/main/java/com/esri/arcgismaps/sample/showexploratoryviewshedfrompointinscene/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/show-extruded-features/build.gradle.kts
+++ b/samples/show-extruded-features/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.showextrudedfeatures"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/show-extruded-features/src/main/java/com/esri/arcgismaps/sample/showextrudedfeatures/MainActivity.kt
+++ b/samples/show-extruded-features/src/main/java/com/esri/arcgismaps/sample/showextrudedfeatures/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/show-extruded-features/src/main/java/com/esri/arcgismaps/sample/showextrudedfeatures/MainActivity.kt
+++ b/samples/show-extruded-features/src/main/java/com/esri/arcgismaps/sample/showextrudedfeatures/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.showextrudedfeatures.screens.ShowExtrudedFeaturesScreen
 

--- a/samples/show-extruded-graphics/build.gradle.kts
+++ b/samples/show-extruded-graphics/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.showextrudedgraphics"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/show-extruded-graphics/src/main/java/com/esri/arcgismaps/sample/showextrudedgraphics/MainActivity.kt
+++ b/samples/show-extruded-graphics/src/main/java/com/esri/arcgismaps/sample/showextrudedgraphics/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.showextrudedgraphics.screens.ShowExtrudedGraphicsScreen
 

--- a/samples/show-extruded-graphics/src/main/java/com/esri/arcgismaps/sample/showextrudedgraphics/MainActivity.kt
+++ b/samples/show-extruded-graphics/src/main/java/com/esri/arcgismaps/sample/showextrudedgraphics/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/show-geodesic-path-between-two-points/build.gradle.kts
+++ b/samples/show-geodesic-path-between-two-points/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/show-geodesic-path-between-two-points/src/main/java/com/esri/arcgismaps/sample/showgeodesicpathbetweentwopoints/MainActivity.kt
+++ b/samples/show-geodesic-path-between-two-points/src/main/java/com/esri/arcgismaps/sample/showgeodesicpathbetweentwopoints/MainActivity.kt
@@ -98,9 +98,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         lifecycle.addObserver(mapView)
 
         // create and add a map with a navigation night basemap style

--- a/samples/show-geodesic-path-between-two-points/src/main/java/com/esri/arcgismaps/sample/showgeodesicpathbetweentwopoints/MainActivity.kt
+++ b/samples/show-geodesic-path-between-two-points/src/main/java/com/esri/arcgismaps/sample/showgeodesicpathbetweentwopoints/MainActivity.kt
@@ -22,8 +22,6 @@ import android.util.Log
 import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.Color
 import com.arcgismaps.geometry.AngularUnit
 import com.arcgismaps.geometry.GeodeticCurveType

--- a/samples/show-grid/build.gradle.kts
+++ b/samples/show-grid/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/show-grid/src/main/java/com/esri/arcgismaps/sample/showgrid/MainActivity.kt
+++ b/samples/show-grid/src/main/java/com/esri/arcgismaps/sample/showgrid/MainActivity.kt
@@ -22,8 +22,6 @@ import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.Color
 import com.arcgismaps.geometry.Point
 import com.arcgismaps.geometry.SpatialReference

--- a/samples/show-grid/src/main/java/com/esri/arcgismaps/sample/showgrid/MainActivity.kt
+++ b/samples/show-grid/src/main/java/com/esri/arcgismaps/sample/showgrid/MainActivity.kt
@@ -89,9 +89,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         lifecycle.addObserver(mapView)
 
         mapView.apply {

--- a/samples/show-labels-on-layer/build.gradle.kts
+++ b/samples/show-labels-on-layer/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/show-labels-on-layer/src/main/java/com/esri/arcgismaps/sample/showlabelsonlayer/MainActivity.kt
+++ b/samples/show-labels-on-layer/src/main/java/com/esri/arcgismaps/sample/showlabelsonlayer/MainActivity.kt
@@ -22,8 +22,6 @@ import android.util.Log
 import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.Color
 import com.arcgismaps.arcgisservices.LabelingPlacement
 import com.arcgismaps.data.ServiceFeatureTable

--- a/samples/show-labels-on-layer/src/main/java/com/esri/arcgismaps/sample/showlabelsonlayer/MainActivity.kt
+++ b/samples/show-labels-on-layer/src/main/java/com/esri/arcgismaps/sample/showlabelsonlayer/MainActivity.kt
@@ -52,9 +52,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         lifecycle.addObserver(mapView)
 
         // create a map with a light gray map style

--- a/samples/show-location-history/build.gradle.kts
+++ b/samples/show-location-history/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/show-location-history/src/main/java/com/esri/arcgismaps/sample/showlocationhistory/MainActivity.kt
+++ b/samples/show-location-history/src/main/java/com/esri/arcgismaps/sample/showlocationhistory/MainActivity.kt
@@ -20,8 +20,6 @@ import android.os.Bundle
 import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.Color
 import com.arcgismaps.geometry.Geometry
 import com.arcgismaps.geometry.Point

--- a/samples/show-location-history/src/main/java/com/esri/arcgismaps/sample/showlocationhistory/MainActivity.kt
+++ b/samples/show-location-history/src/main/java/com/esri/arcgismaps/sample/showlocationhistory/MainActivity.kt
@@ -62,9 +62,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         lifecycle.addObserver(mapView)
 
         // create a center point for the data in West Los Angeles, California

--- a/samples/show-magnifier/build.gradle.kts
+++ b/samples/show-magnifier/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.showmagnifier"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/show-magnifier/src/main/java/com/esri/arcgismaps/sample/showmagnifier/MainActivity.kt
+++ b/samples/show-magnifier/src/main/java/com/esri/arcgismaps/sample/showmagnifier/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/show-magnifier/src/main/java/com/esri/arcgismaps/sample/showmagnifier/MainActivity.kt
+++ b/samples/show-magnifier/src/main/java/com/esri/arcgismaps/sample/showmagnifier/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.showmagnifier.screens.MainScreen
 

--- a/samples/show-mobile-map-package-expiration-date/build.gradle.kts
+++ b/samples/show-mobile-map-package-expiration-date/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.showmobilemappackageexpirationdate"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/show-mobile-map-package-expiration-date/src/main/java/com/esri/arcgismaps/sample/showmobilemappackageexpirationdate/MainActivity.kt
+++ b/samples/show-mobile-map-package-expiration-date/src/main/java/com/esri/arcgismaps/sample/showmobilemappackageexpirationdate/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/show-mobile-map-package-expiration-date/src/main/java/com/esri/arcgismaps/sample/showmobilemappackageexpirationdate/MainActivity.kt
+++ b/samples/show-mobile-map-package-expiration-date/src/main/java/com/esri/arcgismaps/sample/showmobilemappackageexpirationdate/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.showmobilemappackageexpirationdate.screens.ShowMobileMapPackageExpirationDateScreen
 

--- a/samples/show-popup/build.gradle.kts
+++ b/samples/show-popup/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.showpopup"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/show-popup/src/main/java/com/esri/arcgismaps/sample/showpopup/MainActivity.kt
+++ b/samples/show-popup/src/main/java/com/esri/arcgismaps/sample/showpopup/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.showpopup.screens.ShowPopupScreen
 

--- a/samples/show-popup/src/main/java/com/esri/arcgismaps/sample/showpopup/MainActivity.kt
+++ b/samples/show-popup/src/main/java/com/esri/arcgismaps/sample/showpopup/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         enableEdgeToEdge()
         setContent {
             SampleAppTheme {

--- a/samples/show-portal-user-info/build.gradle.kts
+++ b/samples/show-portal-user-info/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.showportaluserinfo"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/show-realistic-light-and-shadows/build.gradle.kts
+++ b/samples/show-realistic-light-and-shadows/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.showrealisticlightandshadows"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/show-realistic-light-and-shadows/src/main/java/com/esri/arcgismaps/sample/showrealisticlightandshadows/MainActivity.kt
+++ b/samples/show-realistic-light-and-shadows/src/main/java/com/esri/arcgismaps/sample/showrealisticlightandshadows/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.showrealisticlightandshadows.screens.ShowRealisticLightAndShadowsScreen
 

--- a/samples/show-realistic-light-and-shadows/src/main/java/com/esri/arcgismaps/sample/showrealisticlightandshadows/MainActivity.kt
+++ b/samples/show-realistic-light-and-shadows/src/main/java/com/esri/arcgismaps/sample/showrealisticlightandshadows/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/show-result-of-spatial-operations/build.gradle.kts
+++ b/samples/show-result-of-spatial-operations/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/show-result-of-spatial-operations/src/main/java/com/esri/arcgismaps/sample/showresultofspatialoperations/MainActivity.kt
+++ b/samples/show-result-of-spatial-operations/src/main/java/com/esri/arcgismaps/sample/showresultofspatialoperations/MainActivity.kt
@@ -80,9 +80,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         lifecycle.addObserver(mapView)
 
         // set up the adapter

--- a/samples/show-result-of-spatial-operations/src/main/java/com/esri/arcgismaps/sample/showresultofspatialoperations/MainActivity.kt
+++ b/samples/show-result-of-spatial-operations/src/main/java/com/esri/arcgismaps/sample/showresultofspatialoperations/MainActivity.kt
@@ -21,8 +21,6 @@ import android.widget.ArrayAdapter
 import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.Color
 import com.arcgismaps.geometry.Geometry
 import com.arcgismaps.geometry.GeometryEngine

--- a/samples/show-result-of-spatial-relationships/build.gradle.kts
+++ b/samples/show-result-of-spatial-relationships/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/show-result-of-spatial-relationships/src/main/java/com/esri/arcgismaps/sample/showresultofspatialrelationships/MainActivity.kt
+++ b/samples/show-result-of-spatial-relationships/src/main/java/com/esri/arcgismaps/sample/showresultofspatialrelationships/MainActivity.kt
@@ -119,9 +119,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         // add MapView to the lifecycle
         lifecycle.addObserver(mapView)
         mapView.apply {

--- a/samples/show-result-of-spatial-relationships/src/main/java/com/esri/arcgismaps/sample/showresultofspatialrelationships/MainActivity.kt
+++ b/samples/show-result-of-spatial-relationships/src/main/java/com/esri/arcgismaps/sample/showresultofspatialrelationships/MainActivity.kt
@@ -21,8 +21,6 @@ import android.util.Log
 import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.Color
 import com.arcgismaps.data.SpatialRelationship
 import com.arcgismaps.geometry.Geometry

--- a/samples/show-scale-bar/build.gradle.kts
+++ b/samples/show-scale-bar/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.showscalebar"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/show-scale-bar/src/main/java/com/esri/arcgismaps/sample/showscalebar/MainActivity.kt
+++ b/samples/show-scale-bar/src/main/java/com/esri/arcgismaps/sample/showscalebar/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.showscalebar.screens.ShowScaleBarScreen
 

--- a/samples/show-scale-bar/src/main/java/com/esri/arcgismaps/sample/showscalebar/MainActivity.kt
+++ b/samples/show-scale-bar/src/main/java/com/esri/arcgismaps/sample/showscalebar/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/show-service-area/build.gradle.kts
+++ b/samples/show-service-area/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.showservicearea"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/show-service-area/src/main/java/com/esri/arcgismaps/sample/showservicearea/MainActivity.kt
+++ b/samples/show-service-area/src/main/java/com/esri/arcgismaps/sample/showservicearea/MainActivity.kt
@@ -23,7 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
 import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.showservicearea.screens.ShowServiceAreaScreen

--- a/samples/show-service-area/src/main/java/com/esri/arcgismaps/sample/showservicearea/MainActivity.kt
+++ b/samples/show-service-area/src/main/java/com/esri/arcgismaps/sample/showservicearea/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         ArcGISEnvironment.applicationContext = this
         enableEdgeToEdge()
         setContent {

--- a/samples/show-viewshed-calculated-from-geoprocessing-task/build.gradle.kts
+++ b/samples/show-viewshed-calculated-from-geoprocessing-task/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.showviewshedcalculatedfromgeoprocessingtask"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/show-viewshed-calculated-from-geoprocessing-task/src/main/java/com/esri/arcgismaps/sample/showviewshedcalculatedfromgeoprocessingtask/MainActivity.kt
+++ b/samples/show-viewshed-calculated-from-geoprocessing-task/src/main/java/com/esri/arcgismaps/sample/showviewshedcalculatedfromgeoprocessingtask/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.showviewshedcalculatedfromgeoprocessingtask.screens.MainScreen
 

--- a/samples/show-viewshed-calculated-from-geoprocessing-task/src/main/java/com/esri/arcgismaps/sample/showviewshedcalculatedfromgeoprocessingtask/MainActivity.kt
+++ b/samples/show-viewshed-calculated-from-geoprocessing-task/src/main/java/com/esri/arcgismaps/sample/showviewshedcalculatedfromgeoprocessingtask/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/snap-geometry-edits-with-utility-network-rules/build.gradle.kts
+++ b/samples/snap-geometry-edits-with-utility-network-rules/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.snapgeometryeditswithutilitynetworkrules"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/snap-geometry-edits-with-utility-network-rules/src/main/java/com/esri/arcgismaps/sample/snapgeometryeditswithutilitynetworkrules/MainActivity.kt
+++ b/samples/snap-geometry-edits-with-utility-network-rules/src/main/java/com/esri/arcgismaps/sample/snapgeometryeditswithutilitynetworkrules/MainActivity.kt
@@ -25,8 +25,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.snapgeometryeditswithutilitynetworkrules.screens.SnapGeometryEditsWithUtilityNetworkRulesScreen
 

--- a/samples/snap-geometry-edits-with-utility-network-rules/src/main/java/com/esri/arcgismaps/sample/snapgeometryeditswithutilitynetworkrules/MainActivity.kt
+++ b/samples/snap-geometry-edits-with-utility-network-rules/src/main/java/com/esri/arcgismaps/sample/snapgeometryeditswithutilitynetworkrules/MainActivity.kt
@@ -35,9 +35,6 @@ class MainActivity : ComponentActivity() {
     @SuppressLint("SourceLockedOrientationActivity")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
 
         enableEdgeToEdge()

--- a/samples/snap-geometry-edits/build.gradle.kts
+++ b/samples/snap-geometry-edits/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.snapgeometryedits"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/snap-geometry-edits/src/main/java/com/esri/arcgismaps/sample/snapgeometryedits/MainActivity.kt
+++ b/samples/snap-geometry-edits/src/main/java/com/esri/arcgismaps/sample/snapgeometryedits/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.snapgeometryedits.screens.MainScreen
 

--- a/samples/snap-geometry-edits/src/main/java/com/esri/arcgismaps/sample/snapgeometryedits/MainActivity.kt
+++ b/samples/snap-geometry-edits/src/main/java/com/esri/arcgismaps/sample/snapgeometryedits/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/style-features-with-custom-dictionary/build.gradle.kts
+++ b/samples/style-features-with-custom-dictionary/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.stylefeatureswithcustomdictionary"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/style-features-with-custom-dictionary/src/main/java/com/esri/arcgismaps/sample/stylefeatureswithcustomdictionary/MainActivity.kt
+++ b/samples/style-features-with-custom-dictionary/src/main/java/com/esri/arcgismaps/sample/stylefeatureswithcustomdictionary/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/style-features-with-custom-dictionary/src/main/java/com/esri/arcgismaps/sample/stylefeatureswithcustomdictionary/MainActivity.kt
+++ b/samples/style-features-with-custom-dictionary/src/main/java/com/esri/arcgismaps/sample/stylefeatureswithcustomdictionary/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.stylefeatureswithcustomdictionary.screens.StyleFeaturesWithCustomDictionaryScreen
 

--- a/samples/style-graphics-with-renderer/build.gradle.kts
+++ b/samples/style-graphics-with-renderer/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/style-graphics-with-renderer/src/main/java/com/esri/arcgismaps/sample/stylegraphicswithrenderer/MainActivity.kt
+++ b/samples/style-graphics-with-renderer/src/main/java/com/esri/arcgismaps/sample/stylegraphicswithrenderer/MainActivity.kt
@@ -63,9 +63,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
         lifecycle.addObserver(mapView)
 
         //  add a map with a topographic basemap style

--- a/samples/style-graphics-with-renderer/src/main/java/com/esri/arcgismaps/sample/stylegraphicswithrenderer/MainActivity.kt
+++ b/samples/style-graphics-with-renderer/src/main/java/com/esri/arcgismaps/sample/stylegraphicswithrenderer/MainActivity.kt
@@ -19,8 +19,6 @@ package com.esri.arcgismaps.sample.stylegraphicswithrenderer
 import android.os.Bundle
 import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.Color
 import com.arcgismaps.geometry.AngularUnit
 import com.arcgismaps.geometry.CubicBezierSegment

--- a/samples/style-graphics-with-symbols/build.gradle.kts
+++ b/samples/style-graphics-with-symbols/build.gradle.kts
@@ -1,12 +1,6 @@
 plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
@@ -14,7 +8,6 @@ android {
     // For view based samples
     buildFeatures {
         dataBinding = true
-        buildConfig = true
     }
 }
 

--- a/samples/style-graphics-with-symbols/src/main/java/com/esri/arcgismaps/sample/stylegraphicswithsymbols/MainActivity.kt
+++ b/samples/style-graphics-with-symbols/src/main/java/com/esri/arcgismaps/sample/stylegraphicswithsymbols/MainActivity.kt
@@ -19,8 +19,6 @@ package com.esri.arcgismaps.sample.stylegraphicswithsymbols
 import android.os.Bundle
 import com.esri.arcgismaps.sample.sampleslib.EdgeToEdgeCompatActivity
 import androidx.databinding.DataBindingUtil
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.arcgismaps.Color
 import com.arcgismaps.geometry.Point
 import com.arcgismaps.geometry.Polygon

--- a/samples/style-graphics-with-symbols/src/main/java/com/esri/arcgismaps/sample/stylegraphicswithsymbols/MainActivity.kt
+++ b/samples/style-graphics-with-symbols/src/main/java/com/esri/arcgismaps/sample/stylegraphicswithsymbols/MainActivity.kt
@@ -49,9 +49,6 @@ class MainActivity : EdgeToEdgeCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         // set up data binding for the activity
         val activityMainBinding: StyleGraphicsWithSymbolsActivityMainBinding =

--- a/samples/style-point-with-distance-composite-scene-symbol/build.gradle.kts
+++ b/samples/style-point-with-distance-composite-scene-symbol/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.stylepointwithdistancecompositescenesymbol"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/style-point-with-distance-composite-scene-symbol/src/main/java/com/esri/arcgismaps/sample/stylepointwithdistancecompositescenesymbol/MainActivity.kt
+++ b/samples/style-point-with-distance-composite-scene-symbol/src/main/java/com/esri/arcgismaps/sample/stylepointwithdistancecompositescenesymbol/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/style-point-with-distance-composite-scene-symbol/src/main/java/com/esri/arcgismaps/sample/stylepointwithdistancecompositescenesymbol/MainActivity.kt
+++ b/samples/style-point-with-distance-composite-scene-symbol/src/main/java/com/esri/arcgismaps/sample/stylepointwithdistancecompositescenesymbol/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.stylepointwithdistancecompositescenesymbol.screens.StylePointWithDistanceCompositeSceneSymbolScreen
 

--- a/samples/style-point-with-scene-symbol/build.gradle.kts
+++ b/samples/style-point-with-scene-symbol/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.stylepointwithscenesymbol"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/style-point-with-scene-symbol/src/main/java/com/esri/arcgismaps/sample/stylepointwithscenesymbol/MainActivity.kt
+++ b/samples/style-point-with-scene-symbol/src/main/java/com/esri/arcgismaps/sample/stylepointwithscenesymbol/MainActivity.kt
@@ -31,9 +31,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         setContent {
             SampleAppTheme {

--- a/samples/style-point-with-scene-symbol/src/main/java/com/esri/arcgismaps/sample/stylepointwithscenesymbol/MainActivity.kt
+++ b/samples/style-point-with-scene-symbol/src/main/java/com/esri/arcgismaps/sample/stylepointwithscenesymbol/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.stylepointwithscenesymbol.screens.StylePointWithSceneSymbolScreen
 

--- a/samples/take-screenshot/build.gradle.kts
+++ b/samples/take-screenshot/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.takescreenshot"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/take-screenshot/src/main/java/com/esri/arcgismaps/sample/takescreenshot/MainActivity.kt
+++ b/samples/take-screenshot/src/main/java/com/esri/arcgismaps/sample/takescreenshot/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.takescreenshot.screens.TakeScreenshotScreen
 

--- a/samples/take-screenshot/src/main/java/com/esri/arcgismaps/sample/takescreenshot/MainActivity.kt
+++ b/samples/take-screenshot/src/main/java/com/esri/arcgismaps/sample/takescreenshot/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/trace-utility-network/build.gradle.kts
+++ b/samples/trace-utility-network/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.traceutilitynetwork"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/trace-utility-network/src/main/java/com/esri/arcgismaps/sample/traceutilitynetwork/MainActivity.kt
+++ b/samples/trace-utility-network/src/main/java/com/esri/arcgismaps/sample/traceutilitynetwork/MainActivity.kt
@@ -24,7 +24,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import com.arcgismaps.ApiKey
 import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.traceutilitynetwork.screens.TraceUtilityNetworkScreen

--- a/samples/trace-utility-network/src/main/java/com/esri/arcgismaps/sample/traceutilitynetwork/MainActivity.kt
+++ b/samples/trace-utility-network/src/main/java/com/esri/arcgismaps/sample/traceutilitynetwork/MainActivity.kt
@@ -33,9 +33,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {

--- a/samples/validate-utility-network-topology/build.gradle.kts
+++ b/samples/validate-utility-network-topology/build.gradle.kts
@@ -2,19 +2,10 @@ plugins {
     alias(libs.plugins.arcgismaps.android.library)
     alias(libs.plugins.arcgismaps.android.library.compose)
     alias(libs.plugins.arcgismaps.kotlin.sample)
-    alias(libs.plugins.gradle.secrets)
-}
-
-secrets {
-    // this file doesn't contain secrets, it just provides defaults which can be committed into git.
-    defaultPropertiesFileName = "secrets.defaults.properties"
 }
 
 android {
     namespace = "com.esri.arcgismaps.sample.validateutilitynetworktopology"
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {

--- a/samples/validate-utility-network-topology/src/main/java/com/esri/arcgismaps/sample/validateutilitynetworktopology/MainActivity.kt
+++ b/samples/validate-utility-network-topology/src/main/java/com/esri/arcgismaps/sample/validateutilitynetworktopology/MainActivity.kt
@@ -23,8 +23,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.arcgismaps.ApiKey
-import com.arcgismaps.ArcGISEnvironment
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.validateutilitynetworktopology.screens.ValidateUtilityNetworkTopologyScreen
 

--- a/samples/validate-utility-network-topology/src/main/java/com/esri/arcgismaps/sample/validateutilitynetworktopology/MainActivity.kt
+++ b/samples/validate-utility-network-topology/src/main/java/com/esri/arcgismaps/sample/validateutilitynetworktopology/MainActivity.kt
@@ -32,9 +32,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // authentication with an API key or named user is
-        // required to access basemaps and other location services
-        ArcGISEnvironment.apiKey = ApiKey.create(BuildConfig.ACCESS_TOKEN)
 
         enableEdgeToEdge()
         setContent {


### PR DESCRIPTION
## Description

PR to remove the usages of `BuildConfig` within samples, and extrapolate the key setting on the top-level sample viewer when [Sample.start](https://github.com/Esri/arcgis-maps-sdk-kotlin-samples/blob/SV/isolate-build-config/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/model/Sample.kt#L132) is invoked. 

## Links and Data

Sample Epic: `runtime/kotlin/issues/7785`
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/277/