### PR TITLE
Add enableEdgeToEdge to samples

### DIFF
--- a/samples/add-elevation-source-from-tile-package/src/main/java/com/esri/arcgismaps/sample/addelevationsourcefromtilepackage/MainActivity.kt
+++ b/samples/add-elevation-source-from-tile-package/src/main/java/com/esri/arcgismaps/sample/addelevationsourcefromtilepackage/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.addelevationsourcefromtilepackage
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 AddElevationSourceFromTilePackageApp()

--- a/samples/add-feature-collection-layer-from-portal-item/src/main/java/com/esri/arcgismaps/sample/addfeaturecollectionlayerfromportalitem/MainActivity.kt
+++ b/samples/add-feature-collection-layer-from-portal-item/src/main/java/com/esri/arcgismaps/sample/addfeaturecollectionlayerfromportalitem/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.addfeaturecollectionlayerfromportalitem
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 AddFeatureCollectionLayerFromPortalItemApp()

--- a/samples/add-feature-collection-layer-from-table/src/main/java/com/esri/arcgismaps/sample/addfeaturecollectionlayerfromtable/MainActivity.kt
+++ b/samples/add-feature-collection-layer-from-table/src/main/java/com/esri/arcgismaps/sample/addfeaturecollectionlayerfromtable/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.addfeaturecollectionlayerfromtable
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 AddFeatureCollectionLayerFromTableApp()

--- a/samples/add-integrated-mesh-layer/src/main/java/com/esri/arcgismaps/sample/addintegratedmeshlayer/MainActivity.kt
+++ b/samples/add-integrated-mesh-layer/src/main/java/com/esri/arcgismaps/sample/addintegratedmeshlayer/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.addintegratedmeshlayer
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 AddIntegratedMeshLayerApp()

--- a/samples/add-kml-layer/src/main/java/com/esri/arcgismaps/sample/addkmllayer/MainActivity.kt
+++ b/samples/add-kml-layer/src/main/java/com/esri/arcgismaps/sample/addkmllayer/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.addkmllayer
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 AddKMLLayerApp()

--- a/samples/add-point-cloud-layer-from-file/src/main/java/com/esri/arcgismaps/sample/addpointcloudlayerfromfile/MainActivity.kt
+++ b/samples/add-point-cloud-layer-from-file/src/main/java/com/esri/arcgismaps/sample/addpointcloudlayerfromfile/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.addpointcloudlayerfromfile
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 AddPointCloudLayerFromFileApp()

--- a/samples/add-raster-from-service/src/main/java/com/esri/arcgismaps/sample/addrasterfromservice/MainActivity.kt
+++ b/samples/add-raster-from-service/src/main/java/com/esri/arcgismaps/sample/addrasterfromservice/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.addrasterfromservice
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 AddRasterFromServiceApp()

--- a/samples/apply-blend-renderer-to-hillshade/src/main/java/com/esri/arcgismaps/sample/applyblendrenderertohillshade/MainActivity.kt
+++ b/samples/apply-blend-renderer-to-hillshade/src/main/java/com/esri/arcgismaps/sample/applyblendrenderertohillshade/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.applyblendrenderertohillshade
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ApplyBlendRendererToHillshadeApp()

--- a/samples/apply-colormap-renderer-to-raster/src/main/java/com/esri/arcgismaps/sample/applycolormaprenderertoraster/MainActivity.kt
+++ b/samples/apply-colormap-renderer-to-raster/src/main/java/com/esri/arcgismaps/sample/applycolormaprenderertoraster/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.applycolormaprenderertoraster
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ApplyColormapRendererToRasterApp()

--- a/samples/apply-dictionary-renderer-to-graphics-overlay/src/main/java/com/esri/arcgismaps/sample/applydictionaryrenderertographicsoverlay/MainActivity.kt
+++ b/samples/apply-dictionary-renderer-to-graphics-overlay/src/main/java/com/esri/arcgismaps/sample/applydictionaryrenderertographicsoverlay/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.applydictionaryrenderertographicsoverlay
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ApplyDictionaryRendererToGraphicsOverlayApp()

--- a/samples/apply-map-algebra/src/main/java/com/esri/arcgismaps/sample/applymapalgebra/MainActivity.kt
+++ b/samples/apply-map-algebra/src/main/java/com/esri/arcgismaps/sample/applymapalgebra/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.applymapalgebra
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ApplyMapAlgebraApp()

--- a/samples/apply-renderers-to-scene-layer/src/main/java/com/esri/arcgismaps/sample/applyrendererstoscenelayer/MainActivity.kt
+++ b/samples/apply-renderers-to-scene-layer/src/main/java/com/esri/arcgismaps/sample/applyrendererstoscenelayer/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.applyrendererstoscenelayer
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ApplyRenderersToSceneLayerApp()

--- a/samples/apply-stretch-renderer/src/main/java/com/esri/arcgismaps/sample/applystretchrenderer/MainActivity.kt
+++ b/samples/apply-stretch-renderer/src/main/java/com/esri/arcgismaps/sample/applystretchrenderer/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.applystretchrenderer
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ApplyStretchRendererApp()

--- a/samples/apply-style-to-wms-layer/src/main/java/com/esri/arcgismaps/sample/applystyletowmslayer/MainActivity.kt
+++ b/samples/apply-style-to-wms-layer/src/main/java/com/esri/arcgismaps/sample/applystyletowmslayer/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.applystyletowmslayer
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ApplyStyleToWMSLayerApp()

--- a/samples/apply-symbology-to-shapefile/src/main/java/com/esri/arcgismaps/sample/applysymbologytoshapefile/MainActivity.kt
+++ b/samples/apply-symbology-to-shapefile/src/main/java/com/esri/arcgismaps/sample/applysymbologytoshapefile/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.applysymbologytoshapefile
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ApplySymbologyToShapefileApp()

--- a/samples/apply-terrain-exaggeration/src/main/java/com/esri/arcgismaps/sample/applyterrainexaggeration/MainActivity.kt
+++ b/samples/apply-terrain-exaggeration/src/main/java/com/esri/arcgismaps/sample/applyterrainexaggeration/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.applyterrainexaggeration
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ApplyTerrainExaggerationApp()

--- a/samples/apply-unique-value-renderer/src/main/java/com/esri/arcgismaps/sample/applyuniquevaluerenderer/MainActivity.kt
+++ b/samples/apply-unique-value-renderer/src/main/java/com/esri/arcgismaps/sample/applyuniquevaluerenderer/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.applyuniquevaluerenderer
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ApplyUniqueValueRendererApp()

--- a/samples/configure-scene-environment/src/main/java/com/esri/arcgismaps/sample/configuresceneenvironment/MainActivity.kt
+++ b/samples/configure-scene-environment/src/main/java/com/esri/arcgismaps/sample/configuresceneenvironment/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.configuresceneenvironment
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ConfigureSceneEnvironmentApp()

--- a/samples/create-buffers-around-points/src/main/java/com/esri/arcgismaps/sample/createbuffersaroundpoints/MainActivity.kt
+++ b/samples/create-buffers-around-points/src/main/java/com/esri/arcgismaps/sample/createbuffersaroundpoints/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.createbuffersaroundpoints
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 CreateBuffersAroundPointsApp()

--- a/samples/display-alternate-symbols-at-different-scales/src/main/java/com/esri/arcgismaps/sample/displayalternatesymbolsatdifferentscales/MainActivity.kt
+++ b/samples/display-alternate-symbols-at-different-scales/src/main/java/com/esri/arcgismaps/sample/displayalternatesymbolsatdifferentscales/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.displayalternatesymbolsatdifferentscales
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 DisplayAlternateSymbolsAtDifferentScalesApp()

--- a/samples/display-local-scene/src/main/java/com/esri/arcgismaps/sample/displaylocalscene/MainActivity.kt
+++ b/samples/display-local-scene/src/main/java/com/esri/arcgismaps/sample/displaylocalscene/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.displaylocalscene
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 DisplayLocalSceneApp()

--- a/samples/filter-building-scene-layer/src/main/java/com/esri/arcgismaps/sample/filterbuildingscenelayer/MainActivity.kt
+++ b/samples/filter-building-scene-layer/src/main/java/com/esri/arcgismaps/sample/filterbuildingscenelayer/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.filterbuildingscenelayer
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -32,6 +33,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         ArcGISEnvironment.applicationContext = this
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 FilterBuildingSceneLayerApp()

--- a/samples/identify-graphics/src/main/java/com/esri/arcgismaps/sample/identifygraphics/MainActivity.kt
+++ b/samples/identify-graphics/src/main/java/com/esri/arcgismaps/sample/identifygraphics/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.identifygraphics
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 IdentifyGraphicsApp()

--- a/samples/match-viewpoint-of-geo-views/src/main/java/com/esri/arcgismaps/sample/matchviewpointofgeoviews/MainActivity.kt
+++ b/samples/match-viewpoint-of-geo-views/src/main/java/com/esri/arcgismaps/sample/matchviewpointofgeoviews/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.matchviewpointofgeoviews
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 MatchViewpointOfGeoViewsApp()

--- a/samples/monitor-changes-to-draw-status/src/main/java/com/esri/arcgismaps/sample/monitorchangestodrawstatus/MainActivity.kt
+++ b/samples/monitor-changes-to-draw-status/src/main/java/com/esri/arcgismaps/sample/monitorchangestodrawstatus/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.monitorchangestodrawstatus
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 MonitorChangesToDrawStatusApp()

--- a/samples/monitor-changes-to-layer-view-state/src/main/java/com/esri/arcgismaps/sample/monitorchangestolayerviewstate/MainActivity.kt
+++ b/samples/monitor-changes-to-layer-view-state/src/main/java/com/esri/arcgismaps/sample/monitorchangestolayerviewstate/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.monitorchangestolayerviewstate
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 MonitorChangesToLayerViewStateApp()

--- a/samples/monitor-changes-to-map-load-status/src/main/java/com/esri/arcgismaps/sample/monitorchangestomaploadstatus/MainActivity.kt
+++ b/samples/monitor-changes-to-map-load-status/src/main/java/com/esri/arcgismaps/sample/monitorchangestomaploadstatus/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.monitorchangestomaploadstatus
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -29,6 +30,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 MonitorChangesToMapLoadStatusApp()

--- a/samples/query-dynamic-entities/src/main/java/com/esri/arcgismaps/sample/querydynamicentities/MainActivity.kt
+++ b/samples/query-dynamic-entities/src/main/java/com/esri/arcgismaps/sample/querydynamicentities/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.querydynamicentities
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 QueryDynamicEntitiesApp()

--- a/samples/set-atmosphere-effect-in-scene/src/main/java/com/esri/arcgismaps/sample/setatmosphereeffectinscene/MainActivity.kt
+++ b/samples/set-atmosphere-effect-in-scene/src/main/java/com/esri/arcgismaps/sample/setatmosphereeffectinscene/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.setatmosphereeffectinscene
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 SetAtmosphereEffectInSceneApp()

--- a/samples/set-basemap/src/main/java/com/esri/arcgismaps/sample/setbasemap/MainActivity.kt
+++ b/samples/set-basemap/src/main/java/com/esri/arcgismaps/sample/setbasemap/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.setbasemap
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 SetBasemapApp()

--- a/samples/set-feature-layer-rendering-mode-on-map/src/main/java/com/esri/arcgismaps/sample/setfeaturelayerrenderingmodeonmap/MainActivity.kt
+++ b/samples/set-feature-layer-rendering-mode-on-map/src/main/java/com/esri/arcgismaps/sample/setfeaturelayerrenderingmodeonmap/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.setfeaturelayerrenderingmodeonmap
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 SetFeatureLayerRenderingModeOnMapApp()

--- a/samples/set-feature-layer-rendering-mode-on-scene/src/main/java/com/esri/arcgismaps/sample/setfeaturelayerrenderingmodeonscene/MainActivity.kt
+++ b/samples/set-feature-layer-rendering-mode-on-scene/src/main/java/com/esri/arcgismaps/sample/setfeaturelayerrenderingmodeonscene/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.setfeaturelayerrenderingmodeonscene
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 SetFeatureLayerRenderingModeOnSceneApp()

--- a/samples/set-initial-map-location/src/main/java/com/esri/arcgismaps/sample/setinitialmaplocation/MainActivity.kt
+++ b/samples/set-initial-map-location/src/main/java/com/esri/arcgismaps/sample/setinitialmaplocation/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.setinitialmaplocation
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 SetInitialMapLocationApp()

--- a/samples/set-initial-viewpoint/src/main/java/com/esri/arcgismaps/sample/setinitialviewpoint/MainActivity.kt
+++ b/samples/set-initial-viewpoint/src/main/java/com/esri/arcgismaps/sample/setinitialviewpoint/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.setinitialviewpoint
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 SetInitialViewpointApp()

--- a/samples/set-min-and-max-scale/src/main/java/com/esri/arcgismaps/sample/setminandmaxscale/MainActivity.kt
+++ b/samples/set-min-and-max-scale/src/main/java/com/esri/arcgismaps/sample/setminandmaxscale/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.setminandmaxscale
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 SetMinAndMaxScaleApp()

--- a/samples/set-reference-scale/src/main/java/com/esri/arcgismaps/sample/setreferencescale/MainActivity.kt
+++ b/samples/set-reference-scale/src/main/java/com/esri/arcgismaps/sample/setreferencescale/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.setreferencescale
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 SetReferenceScaleApp()

--- a/samples/set-spatial-reference/src/main/java/com/esri/arcgismaps/sample/setspatialreference/MainActivity.kt
+++ b/samples/set-spatial-reference/src/main/java/com/esri/arcgismaps/sample/setspatialreference/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.setspatialreference
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 SetSpatialReferenceApp()

--- a/samples/set-surface-navigation-constraint/src/main/java/com/esri/arcgismaps/sample/setsurfacenavigationconstraint/MainActivity.kt
+++ b/samples/set-surface-navigation-constraint/src/main/java/com/esri/arcgismaps/sample/setsurfacenavigationconstraint/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.setsurfacenavigationconstraint
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 SetSurfaceNavigationConstraintApp()

--- a/samples/set-surface-placement-mode/src/main/java/com/esri/arcgismaps/sample/setsurfaceplacementmode/MainActivity.kt
+++ b/samples/set-surface-placement-mode/src/main/java/com/esri/arcgismaps/sample/setsurfaceplacementmode/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.setsurfaceplacementmode
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 SetSurfacePlacementModeApp()

--- a/samples/show-extruded-features/src/main/java/com/esri/arcgismaps/sample/showextrudedfeatures/MainActivity.kt
+++ b/samples/show-extruded-features/src/main/java/com/esri/arcgismaps/sample/showextrudedfeatures/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.showextrudedfeatures
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ShowExtrudedFeaturesApp()

--- a/samples/show-extruded-graphics/src/main/java/com/esri/arcgismaps/sample/showextrudedgraphics/MainActivity.kt
+++ b/samples/show-extruded-graphics/src/main/java/com/esri/arcgismaps/sample/showextrudedgraphics/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.showextrudedgraphics
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ShowExtrudedGraphicsApp()

--- a/samples/show-line-of-sight-analysis-in-map/src/main/java/com/esri/arcgismaps/sample/showlineofsightanalysisinmap/MainActivity.kt
+++ b/samples/show-line-of-sight-analysis-in-map/src/main/java/com/esri/arcgismaps/sample/showlineofsightanalysisinmap/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.showlineofsightanalysisinmap
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -29,6 +30,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 Surface(color = MaterialTheme.colorScheme.background) {

--- a/samples/show-mobile-map-package-expiration-date/src/main/java/com/esri/arcgismaps/sample/showmobilemappackageexpirationdate/MainActivity.kt
+++ b/samples/show-mobile-map-package-expiration-date/src/main/java/com/esri/arcgismaps/sample/showmobilemappackageexpirationdate/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.showmobilemappackageexpirationdate
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 ShowMobileMapPackageExpirationDateApp()

--- a/samples/style-features-with-custom-dictionary/src/main/java/com/esri/arcgismaps/sample/stylefeatureswithcustomdictionary/MainActivity.kt
+++ b/samples/style-features-with-custom-dictionary/src/main/java/com/esri/arcgismaps/sample/stylefeatureswithcustomdictionary/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.stylefeatureswithcustomdictionary
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 StyleFeaturesWithCustomDictionaryApp()

--- a/samples/style-point-with-distance-composite-scene-symbol/src/main/java/com/esri/arcgismaps/sample/stylepointwithdistancecompositescenesymbol/MainActivity.kt
+++ b/samples/style-point-with-distance-composite-scene-symbol/src/main/java/com/esri/arcgismaps/sample/stylepointwithdistancecompositescenesymbol/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.stylepointwithdistancecompositescenesymbol
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 StylePointWithDistanceCompositeSceneSymbolApp()

--- a/samples/style-point-with-scene-symbol/src/main/java/com/esri/arcgismaps/sample/stylepointwithscenesymbol/MainActivity.kt
+++ b/samples/style-point-with-scene-symbol/src/main/java/com/esri/arcgismaps/sample/stylepointwithscenesymbol/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgismaps.sample.stylepointwithscenesymbol
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
         setContent {
             SampleAppTheme {
                 StylePointWithSceneSymbolApp()


### PR DESCRIPTION
## Description

PR to `enableEdgeToEdge` for samples which are missing the support as it used to be added in manually, and has now been [updated](https://github.com/Esri/arcgis-maps-sdk-kotlin-samples/pull/494/changes#diff-31d5a55e8aa27daeaf3b36a7b8dff4a1ff4c9cedffc0218cccc1b0e81b49cfadR34) in scripts. 

## Links and Data


Sample Epic: `runtime/kotlin/issues/7954`
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/Release/job/300.1.0/job/vtest/job/sampleviewer/2/