### PR TITLE
v300.1 pre-release tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ArcGIS Maps SDK Kotlin Samples 
+# ArcGIS Maps SDK Kotlin Samples
 
 [![Link: ArcGIS Developers home](https://img.shields.io/badge/ArcGIS%20Developers%20Home-633b9b?style=flat-square)](https://developers.arcgis.com)
 [![Link: Documentation](https://img.shields.io/badge/Documentation-633b9b?style=flat-square)](https://developers.arcgis.com/kotlin/)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ ArcGIS Maps SDK for Kotlin v300.1.0 samples.  The `main` branch of this reposito
 
 ## Prerequisites
 
-* The samples are building with `targetSdk 36`
+* The samples are building with `targetSdk 37`
 * [Android Studio](http://developer.android.com/sdk/index.html)
 * [An ArcGIS Developers API key](https://developers.arcgis.com/kotlin/get-started/#3-get-an-api-key)
 

--- a/app/src/androidTest/java/com/esri/arcgismaps/kotlin/samples/SampleScenarioTests.kt
+++ b/app/src/androidTest/java/com/esri/arcgismaps/kotlin/samples/SampleScenarioTests.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.withTimeout
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Parameterized test to run all [SampleScenario]s in the [SampleScenarioRegistry].
@@ -59,7 +60,7 @@ class SampleScenarioTests(private val scenario: SampleScenario) {
         ).apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) }
         ActivityScenario.launch<Activity>(intent).use { sampleScenario ->
             for (step in scenario.steps) {
-                withTimeout(scenario.timeoutMs) {
+                withTimeout(scenario.timeoutMs.milliseconds) {
                     lateinit var activity: Activity
                     sampleScenario.onActivity { activity = it }
                     step.action(sampleScope, activity)

--- a/app/src/androidTest/java/com/esri/arcgismaps/kotlin/sampleviewer/SampleInfoRepositoryTest.kt
+++ b/app/src/androidTest/java/com/esri/arcgismaps/kotlin/sampleviewer/SampleInfoRepositoryTest.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Tests for the [DefaultSampleInfoRepository] to verify it correctly loads sample info
@@ -54,7 +55,7 @@ class SampleInfoRepositoryTest {
 
         // Wait for the repository flow to be populated.
         // The StateFlow emits an initial empty list, await until it emits the expected count.
-        val sampleViewerCount = withTimeout(10_000) {
+        val sampleViewerCount = withTimeout(10_000.milliseconds) {
             DefaultSampleInfoRepository.getAllSamples()
                 .first { samples -> samples.size >= jsonCount }
                 .size

--- a/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/viewmodels/SampleSearchViewModel.kt
+++ b/app/src/main/java/com/esri/arcgismaps/kotlin/sampleviewer/viewmodels/SampleSearchViewModel.kt
@@ -43,7 +43,7 @@ class SampleSearchViewModel(private val application: Application) : AndroidViewM
     var searchSuggestions = MutableStateFlow<List<Pair<String, Boolean>>>(emptyList())
         private set
 
-    // Keep track of the scope where DB is queried, so it can be cancelled
+    // Keep track of the scope where DB is queried, so it can be canceled
     // on subsequent searchQuery.
     private var databaseQueryJob: Job? = null
 

--- a/samples-lib/src/main/java/com/esri/arcgismaps/sample/sampleslib/components/JobLoadingDialog.kt
+++ b/samples-lib/src/main/java/com/esri/arcgismaps/sample/sampleslib/components/JobLoadingDialog.kt
@@ -48,7 +48,7 @@ import androidx.compose.ui.window.DialogProperties
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 
 /**
- * Composable component to display an determinate loading dialog along for an ArcGIS Job
+ * Composable component to display a determinate loading dialog along for an ArcGIS Job
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/samples/add-3d-tiles-layer/README.metadata.json
+++ b/samples/add-3d-tiles-layer/README.metadata.json
@@ -30,5 +30,5 @@
         "src/main/java/com/esri/arcgismaps/sample/add3dtileslayer/MainActivity.kt",
         "src/main/java/com/esri/arcgismaps/sample/add3dtileslayer/screens/MainScreen.kt"
     ],
-    "title": "Add 3d tiles layer"
+    "title": "Add 3D Tiles Layer"
 }

--- a/samples/add-3d-tiles-layer/README.metadata.json
+++ b/samples/add-3d-tiles-layer/README.metadata.json
@@ -30,5 +30,5 @@
         "src/main/java/com/esri/arcgismaps/sample/add3dtileslayer/MainActivity.kt",
         "src/main/java/com/esri/arcgismaps/sample/add3dtileslayer/screens/MainScreen.kt"
     ],
-    "title": "Add 3D Tiles Layer"
+    "title": "Add 3d tiles layer"
 }

--- a/samples/add-3d-tiles-layer/src/main/res/values/strings.xml
+++ b/samples/add-3d-tiles-layer/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="add_3d_tiles_layer_app_name">Add 3D Tiles Layer</string>
+    <string name="add_3d_tiles_layer_app_name">Add 3D tiles layer</string>
 </resources>

--- a/samples/add-3d-tiles-layer/src/main/res/values/strings.xml
+++ b/samples/add-3d-tiles-layer/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="add_3d_tiles_layer_app_name">Add 3D tiles layer</string>
+    <string name="add_3d_tiles_layer_app_name">Add 3D Tiles Layer</string>
 </resources>

--- a/samples/add-building-scene-layer/src/main/java/com/esri/arcgismaps/sample/addbuildingscenelayer/screens/AddBuildingSceneLayerScreen.kt
+++ b/samples/add-building-scene-layer/src/main/java/com/esri/arcgismaps/sample/addbuildingscenelayer/screens/AddBuildingSceneLayerScreen.kt
@@ -112,7 +112,7 @@ fun AddBuildingSceneLayerScreen(sampleName: String) {
         }
     }
 
-    // Get the overview and full model sublayers for the seggmented choice button
+    // Get the overview and full model sublayers for the segmented choice button
     LaunchedEffect(Unit) {
         buildingSceneLayer.load().onSuccess {
             val sublayers = buildingSceneLayer.sublayers

--- a/samples/add-custom-dynamic-entity-data-source/src/main/java/com/esri/arcgismaps/sample/addcustomdynamicentitydatasource/components/CustomEntityFeedProvider.kt
+++ b/samples/add-custom-dynamic-entity-data-source/src/main/java/com/esri/arcgismaps/sample/addcustomdynamicentitydatasource/components/CustomEntityFeedProvider.kt
@@ -124,7 +124,7 @@ class CustomEntityFeedProvider(
                 }
             } catch (e: Exception) {
                 if (e is CancellationException) {
-                    // Don't swallow CancellationException to maintain structured concurrency when the coroutine is cancelled.
+                    // Don't swallow CancellationException to maintain structured concurrency when the coroutine is canceled.
                     throw e
                 }
                 withContext(NonCancellable) {

--- a/samples/add-custom-dynamic-entity-data-source/src/main/java/com/esri/arcgismaps/sample/addcustomdynamicentitydatasource/components/MapViewModel.kt
+++ b/samples/add-custom-dynamic-entity-data-source/src/main/java/com/esri/arcgismaps/sample/addcustomdynamicentitydatasource/components/MapViewModel.kt
@@ -53,7 +53,7 @@ class MapViewModel(application: Application) : AndroidViewModel(application) {
     var connectionStatusString by mutableStateOf("")
         private set
 
-    // Set connection status string in he UI.
+    // Set connection status string in the UI.
     private fun updateConnectionStatusString(connectionStatus: String) {
         connectionStatusString = connectionStatus
     }
@@ -147,7 +147,7 @@ class MapViewModel(application: Application) : AndroidViewModel(application) {
         private set
 
     // Keep track of the Coroutine Scope where observations on being collected on, so that it can
-    // be cancelled on subsequent identifies.
+    // be canceled on subsequent identifies.
     private var observationsJob: Job? = null
 
     /**

--- a/samples/add-dynamic-entity-layer/src/main/java/com/esri/arcgismaps/sample/adddynamicentitylayer/screens/MainScreen.kt
+++ b/samples/add-dynamic-entity-layer/src/main/java/com/esri/arcgismaps/sample/adddynamicentitylayer/screens/MainScreen.kt
@@ -47,7 +47,7 @@ import com.esri.arcgismaps.sample.sampleslib.components.SampleTopAppBar
  */
 @Composable
 fun MainScreen(sampleName: String) {
-    /// coroutineScope that will be cancelled when this call leaves the composition
+    /// coroutineScope that will be canceled when this call leaves the composition
     val sampleCoroutineScope = rememberCoroutineScope()
     // get the application context
     val application = LocalContext.current.applicationContext as Application

--- a/samples/add-feature-layers/README.md
+++ b/samples/add-feature-layers/README.md
@@ -49,7 +49,7 @@ Tap the floating action button on the bottom right and select from the various s
 
 This sample uses the [Naperville damage assessment service](https://sampleserver7.arcgisonline.com/server/rest/services/DamageAssessment/FeatureServer/0), [Trees of Portland portal item](https://www.arcgis.com/home/item.html?id=1759fd3e8a324358a0c58d9a687a8578), [Los Angeles Trailheads geodatabase](https://www.arcgis.com/home/item.html?id=cb1b20748a9f4d128dad8a87244e3e37), [Aurora, Colorado GeoPackage](https://www.arcgis.com/home/item.html?id=68ec42517cdd439e81b036210483e8e7), and [Scottish Wildlife Trust Reserves Shapefile](https://www.arcgis.com/home/item.html?id=15a7cbd3af1e47cfa5d2c6b93dc44fc2).
 
-The Scottish Wildlife Trust shapefile data is provided from Scottish Wildlife Trust under [CC-BY licence](https://creativecommons.org/licenses/by/4.0/). Data Copyright Scottish Wildlife Trust (2022).
+The Scottish Wildlife Trust shapefile data is provided from Scottish Wildlife Trust under [CC-BY license](https://creativecommons.org/licenses/by/4.0/). Data Copyright Scottish Wildlife Trust (2022).
 
 ## Tags
 

--- a/samples/add-raster-from-service/README.md
+++ b/samples/add-raster-from-service/README.md
@@ -6,7 +6,7 @@ Create a raster layer from a raster image service.
 
 ## Use case
 
-Accessing a raster image from an online service can be useful for analysing the most up-to-date data available for an area. For example, retrieving recent results of bathymetry surveys within a shipping channel monitored for its sediment build-up would allow planners to assess dredging needs.
+Accessing a raster image from an online service can be useful for analyzing the most up-to-date data available for an area. For example, retrieving recent results of bathymetry surveys within a shipping channel monitored for its sediment build-up would allow planners to assess dredging needs.
 
 ## How to use the sample
 

--- a/samples/analyze-hotspots/src/main/java/com/esri/arcgismaps/sample/analyzehotspots/screens/BottomSheetScreen.kt
+++ b/samples/analyze-hotspots/src/main/java/com/esri/arcgismaps/sample/analyzehotspots/screens/BottomSheetScreen.kt
@@ -48,7 +48,7 @@ fun DateRangeSelectorLayout(
     onRunAnalysisClicked: (Long?, Long?) -> Unit,
     bottomSheetState: SheetState,
 ) {
-    // coroutineScope that will be cancelled when this call leaves the composition
+    // coroutineScope that will be canceled when this call leaves the composition
     val scope = rememberCoroutineScope()
 
     // From: Dec 31st, 1997

--- a/samples/analyze-hotspots/src/main/java/com/esri/arcgismaps/sample/analyzehotspots/screens/MainScreen.kt
+++ b/samples/analyze-hotspots/src/main/java/com/esri/arcgismaps/sample/analyzehotspots/screens/MainScreen.kt
@@ -38,7 +38,7 @@ import kotlinx.coroutines.launch
  */
 @Composable
 fun MainScreen(sampleName: String) {
-    // coroutineScope that will be cancelled when this call leaves the composition
+    // coroutineScope that will be canceled when this call leaves the composition
     val sampleCoroutineScope = rememberCoroutineScope()
     // get the application property that will be used to construct MapViewModel
     val sampleApplication = LocalContext.current.applicationContext as Application

--- a/samples/analyze-network-with-subnetwork-trace/README.md
+++ b/samples/analyze-network-with-subnetwork-trace/README.md
@@ -10,7 +10,7 @@ While some traces are built from an ad-hoc group of parameters, many are based o
 
 ## How to use the sample
 
-The sample loads with a server-defined trace configuration from a tier. Check or uncheck which options to include in the trace - such as containers or barriers. Use the selection boxes to define a new condition network attribute comparison, and then use 'Add' to add the it to the trace configuration. Click 'Trace' to run a subnetwork trace with this modified configuration from a default starting location.
+The sample loads with a server-defined trace configuration from a tier. Check or uncheck which options to include in the trace - such as containers or barriers. Use the selection boxes to define a new condition network attribute comparison, and then use 'Add' to add it to the trace configuration. Click 'Trace' to run a subnetwork trace with this modified configuration from a default starting location.
 
 Example barrier conditions for the default dataset:
 

--- a/samples/analyze-network-with-subnetwork-trace/src/main/java/com/esri/arcgismaps/sample/analyzenetworkwithsubnetworktrace/MainActivity.kt
+++ b/samples/analyze-network-with-subnetwork-trace/src/main/java/com/esri/arcgismaps/sample/analyzenetworkwithsubnetworktrace/MainActivity.kt
@@ -36,7 +36,6 @@ import com.arcgismaps.LoadStatus
 import com.arcgismaps.data.CodedValue
 import com.arcgismaps.data.CodedValueDomain
 import com.arcgismaps.data.ServiceGeodatabase
-import com.arcgismaps.httpcore.authentication.ArcGISAuthenticationChallenge
 import com.arcgismaps.httpcore.authentication.ArcGISAuthenticationChallengeHandler
 import com.arcgismaps.httpcore.authentication.ArcGISAuthenticationChallengeResponse
 import com.arcgismaps.httpcore.authentication.TokenCredential
@@ -64,7 +63,6 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.textfield.TextInputEditText
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 
 class MainActivity : EdgeToEdgeCompatActivity() {
 

--- a/samples/analyze-network-with-subnetwork-trace/src/main/java/com/esri/arcgismaps/sample/analyzenetworkwithsubnetworktrace/MainActivity.kt
+++ b/samples/analyze-network-with-subnetwork-trace/src/main/java/com/esri/arcgismaps/sample/analyzenetworkwithsubnetworktrace/MainActivity.kt
@@ -36,6 +36,7 @@ import com.arcgismaps.LoadStatus
 import com.arcgismaps.data.CodedValue
 import com.arcgismaps.data.CodedValueDomain
 import com.arcgismaps.data.ServiceGeodatabase
+import com.arcgismaps.httpcore.authentication.ArcGISAuthenticationChallenge
 import com.arcgismaps.httpcore.authentication.ArcGISAuthenticationChallengeHandler
 import com.arcgismaps.httpcore.authentication.ArcGISAuthenticationChallengeResponse
 import com.arcgismaps.httpcore.authentication.TokenCredential
@@ -229,9 +230,8 @@ class MainActivity : EdgeToEdgeCompatActivity() {
      */
     private fun getAuthenticationChallengeHandler(): ArcGISAuthenticationChallengeHandler {
         return ArcGISAuthenticationChallengeHandler { challenge ->
-            val result: Result<TokenCredential> = runBlocking {
+            val result: Result<TokenCredential> =
                 TokenCredential.create(challenge.requestUrl, "viewer01", "I68VGU^nMurF", 0)
-            }
             if (result.getOrNull() != null) {
                 val credential = result.getOrNull()
                 return@ArcGISAuthenticationChallengeHandler ArcGISAuthenticationChallengeResponse

--- a/samples/apply-dictionary-renderer-to-graphics-overlay/src/main/java/com/esri/arcgismaps/sample/applydictionaryrenderertographicsoverlay/components/ApplyDictionaryRendererToGraphicsOverlayViewModel.kt
+++ b/samples/apply-dictionary-renderer-to-graphics-overlay/src/main/java/com/esri/arcgismaps/sample/applydictionaryrenderertographicsoverlay/components/ApplyDictionaryRendererToGraphicsOverlayViewModel.kt
@@ -87,7 +87,7 @@ class ApplyDictionaryRendererToGraphicsOverlayViewModel(private val app: Applica
                 graphics.addAll(pointGraphics)
             }
 
-            // Sets the camera to look a the graphics in the graphics overlay
+            // Sets the camera to look at the graphics in the graphics overlay
             graphicsOverlay.extent?.let { extent ->
                 sceneViewProxy.setViewpointCamera(
                     camera = Camera(

--- a/samples/apply-stretch-renderer/src/main/java/com/esri/arcgismaps/sample/applystretchrenderer/components/ApplyStretchRendererViewModel.kt
+++ b/samples/apply-stretch-renderer/src/main/java/com/esri/arcgismaps/sample/applystretchrenderer/components/ApplyStretchRendererViewModel.kt
@@ -127,28 +127,28 @@ class ApplyStretchRendererViewModel(private val app: Application) : AndroidViewM
         updateRenderer()
     }
 
-    /** Update MinMax minimum value (clamped to 0..(max-1)). */
+    /** Update MinMax minimum value (clamped to 0...(max-1)). */
     fun updateMinValue(value: Double) {
         val max = _maxValue.value
         _minValue.value = value.coerceIn(DEFAULT_MIN, max - 1.0)
         updateRenderer()
     }
 
-    /** Update MinMax maximum value (clamped to (min+1)..255). */
+    /** Update MinMax maximum value (clamped to (min+1)...255). */
     fun updateMaxValue(value: Double) {
         val min = _minValue.value
         _maxValue.value = value.coerceIn(min + 1.0, 255.0)
         updateRenderer()
     }
 
-    /** Update Percent Clip minimum percent (clamped to 0..percentMax). */
+    /** Update Percent Clip minimum percent (clamped to 0...percentMax). */
     fun updatePercentMin(value: Double) {
         val max = _percentMax.value
         _percentMin.value = value.coerceIn(DEFAULT_MIN, max)
         updateRenderer()
     }
 
-    /** Update Percent Clip maximum percent (clamped to percentMin..100). */
+    /** Update Percent Clip maximum percent (clamped to percentMin...100). */
     fun updatePercentMax(value: Double) {
         val min = _percentMin.value
         _percentMax.value = value.coerceIn(min, 100.0)

--- a/samples/apply-stretch-renderer/src/main/java/com/esri/arcgismaps/sample/applystretchrenderer/screens/ApplyStretchRendererScreen.kt
+++ b/samples/apply-stretch-renderer/src/main/java/com/esri/arcgismaps/sample/applystretchrenderer/screens/ApplyStretchRendererScreen.kt
@@ -229,7 +229,7 @@ fun PercentClipSettings(
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
         Text("Percent Clip Parameters", style = MaterialTheme.typography.titleMedium)
 
-        // Percent min slider (0 .. percentMax)
+        // Percent min slider (0 ... percentMax)
         Text(text = " Min %: ${range.start.toInt()}  Max %: ${range.endInclusive.toInt()}")
         RangeSlider(
             value = range,
@@ -263,7 +263,7 @@ fun StdDevSettings(
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
         Text("Standard Deviation Parameters", style = MaterialTheme.typography.titleMedium)
 
-        // Factor slider (0.25 .. 4.0)
+        // Factor slider (0.25 ... 4.0)
         Text(text = "Factor: %.2f".format(stdDevFactor))
         Slider(
             value = stdDevFactor.toFloat(),

--- a/samples/apply-style-to-wms-layer/README.md
+++ b/samples/apply-style-to-wms-layer/README.md
@@ -15,7 +15,7 @@ Once the layer loads, the toggle button will be enabled. Click it to toggle betw
 ## How it works
 
 1. Create a `WmsLayer` specifying the URL of the service and the layer names you want `WmsLayer(url, names)`.
-2. When the layer is done loading, get it's list of style strings using `wmsLayer.layerInfos.firstOrNull()?.styles`.
+2. When the layer is done loading, get its list of style strings using `wmsLayer.layerInfos.firstOrNull()?.styles`.
 3. Set one of the styles using `wmsSublayer.currentStyle = styleString`.
 
 ## Relevant API

--- a/samples/augment-reality-to-collect-data/README.md
+++ b/samples/augment-reality-to-collect-data/README.md
@@ -10,7 +10,7 @@ You can use AR to quickly photograph an object and automatically determine the o
 
 ## How to use the sample
 
-Before you start, ensure the device has good satellite visibility (ie. no trees or ceilings overhead) or, if using `WorldScaleTrackingMode.Geospatial`, that the device is outside in an area with VPS availability. This sample will indicate whether the device has VPS availability when in Geospatial tracking mode.
+Before you start, ensure the device has good satellite visibility (i.e. no trees or ceilings overhead) or, if using `WorldScaleTrackingMode.Geospatial`, that the device is outside in an area with VPS availability. This sample will indicate whether the device has VPS availability when in Geospatial tracking mode.
 
 When you tap, a yellow diamond will appear at the tapped location. You can move around to visually verify that the tapped point is in the correct physical location. When you're satisfied, tap the '+' button to record the feature.
 
@@ -42,7 +42,7 @@ This sample requires a device that is compatible with [ARCore](https://developer
 
 The `onSingleTapConfirmed` lambda parameter to the `WorldScaleSceneView` passes a `mapPoint` parameter when it is able to determine the real-world location of the tapped point. On devices that support [ARCore's Depth API](https://developers.google.com/ar/develop/depth#device_compatibility), this point is represents the closest visible object to the device at the tapped screen point in the camera feed. On devices that do not support the Depth API, ARCore will attempt to perform a [hit test](https://developers.google.com/ar/develop/hit-test) against any planes that were detected in the scene at that location. If no planes are detected, then `mapPoint` will be null.
 
-Note that the `WorldScaleSceneViewProxy` also supports converting screen coordinates to scene points using `WorldScaleSceneViewProxy.screenToBaseSurface()` and `WorldScaleSceneViewProxy.screenToLocation()`. However, these methods will test the screen coordinate against virtual objects in the scene, so real-world objects that do not have geometry (ie. a mesh) will not be used for the calculation. Therefore, `screenToBaseSurface()` and `screenToLocation()` should only be used where the developer is sure that the data contains geometry for the real-world object in the camera feed.
+Note that the `WorldScaleSceneViewProxy` also supports converting screen coordinates to scene points using `WorldScaleSceneViewProxy.screenToBaseSurface()` and `WorldScaleSceneViewProxy.screenToLocation()`. However, these methods will test the screen coordinate against virtual objects in the scene, so real-world objects that do not have geometry (i.e. a mesh) will not be used for the calculation. Therefore, `screenToBaseSurface()` and `screenToLocation()` should only be used where the developer is sure that the data contains geometry for the real-world object in the camera feed.
 
 This sample uses the `onSingleTapConfirmed` lambda, as it is the only way to get accurate positions for features present in the real-world but not present in the scene, such as trees.
 

--- a/samples/augment-reality-to-collect-data/src/main/java/com/esri/arcgismaps/sample/augmentrealitytocollectdata/components/AugmentRealityToCollectDataViewModel.kt
+++ b/samples/augment-reality-to-collect-data/src/main/java/com/esri/arcgismaps/sample/augmentrealitytocollectdata/components/AugmentRealityToCollectDataViewModel.kt
@@ -45,6 +45,7 @@ import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.sample
 import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.milliseconds
 
 class AugmentRealityToCollectDataViewModel(app: Application) : AndroidViewModel(app) {
     private val basemap = Basemap(BasemapStyle.ArcGISHumanGeography)
@@ -160,7 +161,7 @@ class AugmentRealityToCollectDataViewModel(app: Application) : AndroidViewModel(
     private fun periodicallyPollVpsAvailability(){
         viewModelScope.launch {
             viewpointCameraLocationFlow
-                .sample(10_000)
+                .sample(10_000.milliseconds)
                 .collect { location ->
                     worldScaleSceneViewProxy.checkVpsAvailability(location.y, location.x).onSuccess {
                         isVpsAvailable = it == WorldScaleVpsAvailability.Available

--- a/samples/augment-reality-to-collect-data/src/main/java/com/esri/arcgismaps/sample/augmentrealitytocollectdata/screens/AugmentRealityToCollectDataScreen.kt
+++ b/samples/augment-reality-to-collect-data/src/main/java/com/esri/arcgismaps/sample/augmentrealitytocollectdata/screens/AugmentRealityToCollectDataScreen.kt
@@ -86,7 +86,7 @@ fun AugmentRealityToCollectDataScreen(sampleName: String) {
     val context = LocalContext.current
 
     val hasNonDefaultAPIKey = BuildConfig.GOOGLE_API_KEY != "DEFAULT_GOOGLE_API_KEY"
-    // Initialize the world scale tracking mode based on whether a google API key is provided
+    // Initialize the world scale tracking mode based on whether a Google API key is provided
     val worldScaleTrackingMode = remember {
         when {
             hasNonDefaultAPIKey -> { WorldScaleTrackingMode.Geospatial() }

--- a/samples/augment-reality-to-navigate-route/src/main/java/com/esri/arcgismaps/sample/augmentrealitytonavigateroute/components/AugmentedRealityViewModel.kt
+++ b/samples/augment-reality-to-navigate-route/src/main/java/com/esri/arcgismaps/sample/augmentrealitytonavigateroute/components/AugmentedRealityViewModel.kt
@@ -58,6 +58,7 @@ import java.lang.Math.toDegrees
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.math.abs
 import kotlin.math.atan2
+import kotlin.time.Duration.Companion.milliseconds
 
 class AugmentedRealityViewModel(app: Application) : AndroidViewModel(app) {
 
@@ -425,7 +426,7 @@ class AugmentedRealityViewModel(app: Application) : AndroidViewModel(app) {
                     val scaleFactor = 1 + 0.2 * kotlin.math.sin(2 * kotlin.math.PI * progress)
                     symbol.height = 1 * scaleFactor
                     symbol.depth = 2 * scaleFactor
-                    delay(frameDelay)
+                    delay(frameDelay.milliseconds)
                 }
             }
         }

--- a/samples/augment-reality-to-navigate-route/src/main/java/com/esri/arcgismaps/sample/augmentrealitytonavigateroute/screens/AugmentedRealityScreen.kt
+++ b/samples/augment-reality-to-navigate-route/src/main/java/com/esri/arcgismaps/sample/augmentrealitytonavigateroute/screens/AugmentedRealityScreen.kt
@@ -97,7 +97,7 @@ fun AugmentedRealityScreen(
     var displayCalibrationView by remember { mutableStateOf(false) }
     var initializationStatus by rememberWorldScaleSceneViewStatus()
 
-    // Initialize the world scale tracking mode based on whether a google API key is provided
+    // Initialize the world scale tracking mode based on whether a Google API key is provided
     val initialWorldScaleTrackingMode = when {
         SharedRepository.hasNonDefaultAPIKey -> { WorldScaleTrackingMode.Geospatial() }
         else -> { WorldScaleTrackingMode.World() }

--- a/samples/augment-reality-to-navigate-route/src/main/java/com/esri/arcgismaps/sample/augmentrealitytonavigateroute/screens/RouteScreen.kt
+++ b/samples/augment-reality-to-navigate-route/src/main/java/com/esri/arcgismaps/sample/augmentrealitytonavigateroute/screens/RouteScreen.kt
@@ -70,7 +70,7 @@ fun RouteScreen(
                 arcGISMap = routeViewModel.arcGISMap,
                 locationDisplay = locationDisplay,
                 graphicsOverlays = routeViewModel.graphicsOverlays,
-                onSingleTapConfirmed = { tap -> tap.mapPoint?.let { it -> routeViewModel.addRoutePoint(it) } })
+                onSingleTapConfirmed = { tap -> tap.mapPoint?.let { routeViewModel.addRoutePoint(it) } })
             if (routeViewModel.statusText.value != "") {
                 // Add directions text box at the top of the screen
                 Box(

--- a/samples/augment-reality-to-show-hidden-infrastructure/src/main/java/com/esri/arcgismaps/sample/augmentrealitytoshowhiddeninfrastructure/components/AugmentedRealityViewModel.kt
+++ b/samples/augment-reality-to-show-hidden-infrastructure/src/main/java/com/esri/arcgismaps/sample/augmentrealitytoshowhiddeninfrastructure/components/AugmentedRealityViewModel.kt
@@ -160,7 +160,7 @@ class AugmentedRealityViewModel(app: Application) : AndroidViewModel(app) {
         // For each point in each part of the densified polyline
         pipePolyline.parts.forEach { part ->
             part.points.forEach { point ->
-                // Create a line from the 3D pipe vertex to a pont offset by the elevation offset
+                // Create a line from the 3D pipe vertex to a point offset by the elevation offset
                 val offsetPoint = GeometryEngine.createWithZ(
                     point,
                     point.z?.minus(elevationOffset)

--- a/samples/augment-reality-to-show-hidden-infrastructure/src/main/java/com/esri/arcgismaps/sample/augmentrealitytoshowhiddeninfrastructure/screens/AugmentedRealityScreen.kt
+++ b/samples/augment-reality-to-show-hidden-infrastructure/src/main/java/com/esri/arcgismaps/sample/augmentrealitytoshowhiddeninfrastructure/screens/AugmentedRealityScreen.kt
@@ -82,7 +82,7 @@ fun AugmentedRealityScreen(sampleName: String) {
     var displayCalibrationView by remember { mutableStateOf(false) }
     var initializationStatus by rememberWorldScaleSceneViewStatus()
 
-    // Initialize the world scale tracking mode based on whether a google API key is provided
+    // Initialize the world scale tracking mode based on whether a Google API key is provided
     val initialWorldScaleTrackingMode = when {
         SharedRepository.hasNonDefaultAPIKey -> { WorldScaleTrackingMode.Geospatial() }
         else -> { WorldScaleTrackingMode.World() }

--- a/samples/browse-building-floors/src/main/java/com/esri/arcgismaps/sample/browsebuildingfloors/MainActivity.kt
+++ b/samples/browse-building-floors/src/main/java/com/esri/arcgismaps/sample/browsebuildingfloors/MainActivity.kt
@@ -168,7 +168,7 @@ class MainActivity : EdgeToEdgeCompatActivity() {
             val view = convertView ?: mLayoutInflater.inflate(layoutResourceId, parent, false)
             val dropdownItemTV = view.findViewById<TextView>(android.R.id.text1)
 
-            // bind the long name of the floor to it's respective text view
+            // bind the long name of the floor to its respective text view
             dropdownItemTV.text = floorLevels[position].longName
             return view
         }

--- a/samples/change-camera-controller/src/main/java/com/esri/arcgismaps/sample/changecameracontroller/MainActivity.kt
+++ b/samples/change-camera-controller/src/main/java/com/esri/arcgismaps/sample/changecameracontroller/MainActivity.kt
@@ -156,7 +156,7 @@ class MainActivity : EdgeToEdgeCompatActivity() {
             sceneView.setViewpointCamera(defaultCamera)
             // copy the airplane model assets to the cache directory if needed
             copyAssetsToCache(assetFiles, cacheDir, false)
-            // load the airplane model file and update the the airplane3DGraphic
+            // load the airplane model file and update the airplane3DGraphic
             loadModel(getString(R.string.bristol_model_file), airplane3DGraphic)
         }
 
@@ -225,7 +225,7 @@ class MainActivity : EdgeToEdgeCompatActivity() {
                 if (!outFile.exists() || overwrite) {
                     // create an input stream to the asset
                     assetManager.open(assetName).use { inputStream ->
-                        // create an file output stream to the output file
+                        // create a file output stream to the output file
                         FileOutputStream(outFile).use { outputStream ->
                             // copy the input file stream to the output file stream
                             inputStream.copyTo(outputStream)

--- a/samples/clip-geometry/README.md
+++ b/samples/clip-geometry/README.md
@@ -14,8 +14,8 @@ Tap the "Clip" button to clip the blue graphic with the red dashed envelopes.
 
 ## How it works
 
-1.  Use the static method `GeometryEngine.clip()` to generate a clipped `Geometry`, passing in an existing `Geometry` and an `Envelope` as parameters.  The existing geometry will be clipped where it intersects an envelope.
-2.  Create a new `Graphic` from the clipped geometry and add it to a `GraphicsOverlay` on the `MapView`.
+1. Use the static method `GeometryEngine.clip()` to generate a clipped `Geometry`, passing in an existing `Geometry` and an `Envelope` as parameters. The existing geometry will be clipped where it intersects an envelope.
+2. Create a new `Graphic` from the clipped geometry and add it to a `GraphicsOverlay` on the `MapView`.
 
 ## Relevant API
 

--- a/samples/clip-geometry/src/main/java/com/esri/arcgismaps/sample/clipgeometry/components/ClipGeometryViewModel.kt
+++ b/samples/clip-geometry/src/main/java/com/esri/arcgismaps/sample/clipgeometry/components/ClipGeometryViewModel.kt
@@ -146,21 +146,21 @@ class ClipGeometryViewModel(application: Application) : AndroidViewModel(applica
         // create a dotted red outline symbol
         val redOutline = SimpleLineSymbol(SimpleLineSymbolStyle.Dot, Color.red, 3f)
 
-        // create a envelope outside Colorado
+        // create an envelope outside Colorado
         val outsideEnvelope = Envelope(
             Point(-11858344.321294, 5147942.225174),
             Point(-12201990.219681, 5297071.577304)
         )
         val outside = Graphic(outsideEnvelope, redOutline)
 
-        // create a envelope intersecting Colorado
+        // create an envelope intersecting Colorado
         val intersectingEnvelope = Envelope(
             Point(-11962086.479298, 4566553.881363),
             Point(-12260345.183558, 4332053.378376)
         )
         val intersecting = Graphic(intersectingEnvelope, redOutline)
 
-        // create a envelope inside Colorado
+        // create an envelope inside Colorado
         val insideEnvelope = Envelope(
             Point(-11655182.595204, 4741618.772994),
             Point(-11431488.567009, 4593570.068343)

--- a/samples/configure-scene-environment/src/main/java/com/esri/arcgismaps/sample/configuresceneenvironment/screens/ConfigureSceneEnvironmentScreen.kt
+++ b/samples/configure-scene-environment/src/main/java/com/esri/arcgismaps/sample/configuresceneenvironment/screens/ConfigureSceneEnvironmentScreen.kt
@@ -278,7 +278,7 @@ private fun formatTimeFromSeconds(seconds: Float): String {
     return localTime.format(timeOfDayFormatter)
 }
 
-/** Maps ArcGIS [Color] values (0..255 channels) to Compose [ComposeColor] (0f..1f channels). */
+/** Maps ArcGIS [Color] values (0..255 channels) to Compose [ComposeColor] (0f...1f channels). */
 private fun Color.toComposeColor(): ComposeColor = ComposeColor(
     red = red / 255f,
     green = green / 255f,

--- a/samples/create-and-save-map/src/main/java/com/esri/arcgismaps/sample/createandsavemap/components/MapViewModel.kt
+++ b/samples/create-and-save-map/src/main/java/com/esri/arcgismaps/sample/createandsavemap/components/MapViewModel.kt
@@ -150,7 +150,7 @@ class MapViewModel(application: Application) : AndroidViewModel(application) {
                 worldElevation.load()
                 usCensus.load()
             }.onFailure {
-                // login was cancelled or failed to authenticate
+                // login was canceled or failed to authenticate
                 messageDialogVM.showMessageDialog(
                     application.getString(R.string.createAndSaveMap_failedToLoadPortal),
                     it.message.toString()

--- a/samples/display-alternate-symbols-at-different-scales/src/main/java/com/esri/arcgismaps/sample/displayalternatesymbolsatdifferentscales/components/DisplayAlternateSymbolsAtDifferentScalesViewModel.kt
+++ b/samples/display-alternate-symbols-at-different-scales/src/main/java/com/esri/arcgismaps/sample/displayalternatesymbolsatdifferentscales/components/DisplayAlternateSymbolsAtDifferentScalesViewModel.kt
@@ -49,7 +49,7 @@ class DisplayAlternateSymbolsAtDifferentScalesViewModel(app: Application) : Andr
         )
     )
 
-    // Map initialized to the a viewpoint and feature layer.
+    // Map initialized to the viewpoint and feature layer.
     val arcGISMap: ArcGISMap = ArcGISMap(BasemapStyle.ArcGISTopographic).apply {
         val center = Point(
             x = -13631200.0,

--- a/samples/display-clusters/src/main/java/com/esri/arcgismaps/sample/displayclusters/screens/MainScreen.kt
+++ b/samples/display-clusters/src/main/java/com/esri/arcgismaps/sample/displayclusters/screens/MainScreen.kt
@@ -48,7 +48,7 @@ import com.esri.arcgismaps.sample.sampleslib.theme.SampleTypography
 @Composable
 fun MainScreen(sampleName: String) {
 
-    // coroutineScope that will be cancelled when this call leaves the composition
+    // coroutineScope that will be canceled when this call leaves the composition
     val sampleCoroutineScope = rememberCoroutineScope()
     // get the application context
     val application = LocalContext.current.applicationContext as Application

--- a/samples/display-map-from-mobile-map-package/README.md
+++ b/samples/display-map-from-mobile-map-package/README.md
@@ -34,4 +34,4 @@ This sample uses the GeoView-Compose Toolkit module to be able to implement a co
 
 ## Tags
 
-geoview-compose, mmpk, mobile map package, offline, tookit
+geoview-compose, mmpk, mobile map package, offline, toolkit

--- a/samples/display-map-from-mobile-map-package/README.metadata.json
+++ b/samples/display-map-from-mobile-map-package/README.metadata.json
@@ -11,7 +11,7 @@
         "mmpk",
         "mobile map package",
         "offline",
-        "tookit",
+        "toolkit",
         "MapView",
         "MobileMapPackage"
     ],

--- a/samples/display-scene/src/main/java/com/esri/arcgismaps/sample/displayscene/MainActivity.kt
+++ b/samples/display-scene/src/main/java/com/esri/arcgismaps/sample/displayscene/MainActivity.kt
@@ -46,7 +46,7 @@ class MainActivity : EdgeToEdgeCompatActivity() {
             resources.getString(R.string.elevation_image_service)
         )
 
-        // create a scene with a imagery basemap style
+        // create a scene with an imagery basemap style
         val imageryScene = ArcGISScene(BasemapStyle.ArcGISImagery).apply {
             // add the elevation source to the base surface
             baseSurface.elevationSources.add(elevationSource)

--- a/samples/edit-geometries-with-programmatic-reticle-tool/src/main/java/com/esri/arcgismaps/sample/editgeometrieswithprogrammaticreticletool/components/EditGeometriesWithProgrammaticReticleToolViewModel.kt
+++ b/samples/edit-geometries-with-programmatic-reticle-tool/src/main/java/com/esri/arcgismaps/sample/editgeometrieswithprogrammaticreticletool/components/EditGeometriesWithProgrammaticReticleToolViewModel.kt
@@ -214,7 +214,7 @@ class EditGeometriesWithProgrammaticReticleToolViewModel(app: Application) : And
 
     /**
      * Performs different actions based on the editor's current hovered and picked up element, as
-     * well as whether vertex creation is allowed. The behaviour is as follows:
+     * well as whether vertex creation is allowed. The behavior is as follows:
      * - If the editor is stopped, starts it with a new geometry with the currently-selected geometry type
      * - Otherwise, if there is a picked up element, places it under the reticle
      * - Otherwise, if a vertex or mid-vertex is hovered over, picks it up

--- a/samples/filter-building-scene-layer/src/main/java/com/esri/arcgismaps/sample/filterbuildingscenelayer/components/FilterBuildingSceneLayerViewModel.kt
+++ b/samples/filter-building-scene-layer/src/main/java/com/esri/arcgismaps/sample/filterbuildingscenelayer/components/FilterBuildingSceneLayerViewModel.kt
@@ -112,7 +112,7 @@ class FilterBuildingSceneLayerViewModel(app: Application) : AndroidViewModel(app
                 buildingSceneLayer.activeFilter = null
                 return
             }
-            // Build a building filter to show the selected floor and an xray view of the floors below.
+            // Build a building filter to show the selected floor and a xray view of the floors below.
             // Floors above the selected floor are not shown at all.
             val buildingFilter = BuildingFilter(
                 name = "Floor filter",

--- a/samples/filter-building-scene-layer/src/main/java/com/esri/arcgismaps/sample/filterbuildingscenelayer/screens/FilterBuildingSceneLayerScreen.kt
+++ b/samples/filter-building-scene-layer/src/main/java/com/esri/arcgismaps/sample/filterbuildingscenelayer/screens/FilterBuildingSceneLayerScreen.kt
@@ -62,6 +62,7 @@ import com.esri.arcgismaps.sample.sampleslib.components.MessageDialog
 import com.esri.arcgismaps.sample.sampleslib.components.SampleTopAppBar
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Main screen layout for the sample app
@@ -123,7 +124,7 @@ var isBottomSheetVisible by remember { mutableStateOf(false) }
 
                             // only show identify progress if it has been more than one second
                             val identifyInProgress = coroutineScope.launch {
-                                delay(1000)
+                                delay(1000.milliseconds)
                                 showIdentifyProgress = true
                             }
 

--- a/samples/find-address-with-reverse-geocode/src/main/java/com/esri/arcgismaps/sample/findaddresswithreversegeocode/MainActivity.kt
+++ b/samples/find-address-with-reverse-geocode/src/main/java/com/esri/arcgismaps/sample/findaddresswithreversegeocode/MainActivity.kt
@@ -79,7 +79,7 @@ class MainActivity : EdgeToEdgeCompatActivity() {
         lifecycle.addObserver(mapView)
 
         mapView.apply {
-            // add a map with a imagery basemap style
+            // add a map with an imagery basemap style
             map = ArcGISMap(BasemapStyle.ArcGISImagery)
             // add a graphics overlay to the map for showing where the user tapped
             graphicsOverlays.add(graphicsOverlay)

--- a/samples/find-route-in-transport-network/src/main/java/com/esri/arcgismaps/sample/findrouteintransportnetwork/MainActivity.kt
+++ b/samples/find-route-in-transport-network/src/main/java/com/esri/arcgismaps/sample/findrouteintransportnetwork/MainActivity.kt
@@ -267,7 +267,7 @@ class MainActivity : EdgeToEdgeCompatActivity() {
      * symbol will be placed at the [locationPoint].
      */
     private fun createStopSymbol(stopNumber: Int, locationPoint: Point?) {
-        // create a orange pin PictureMarkerSymbol
+        // create an orange pin PictureMarkerSymbol
         val pinSymbol = PictureMarkerSymbol.createWithImage(
             ContextCompat.getDrawable(
                 this,

--- a/samples/generate-offline-map-using-android-jetpack-workmanager/README.md
+++ b/samples/generate-offline-map-using-android-jetpack-workmanager/README.md
@@ -38,7 +38,7 @@ When the app
    1. The worker is killed and the download/notifications stop.
    2. The worker is restarted upon next launch.
 
-### Notification behaviour
+### Notification behavior
 
 1. Progress push notification are posted when the `OfflineJobWorker` is running.
 2. Once the worker is done, either a "Completed" or "Failed" notification is posted.
@@ -59,7 +59,7 @@ The map used in this sample shows the [stormwater network](https://arcgisruntime
 ## Additional information
 
 The creation of the offline map can be fine-tuned using [parameter overrides for feature layers](https://github.com/Esri/arcgis-runtime-samples-android/tree/master/java/generate-offline-map-overrides), or by using [local basemaps](https://github.com/Esri/arcgis-runtime-samples-android/tree/master/java/generate-offline-map-with-local-basemap)
-to achieve more customised results.
+to achieve more customized results.
 
 ## Tags
 

--- a/samples/generate-offline-map-using-android-jetpack-workmanager/src/main/java/com/esri/arcgismaps/sample/generateofflinemapusingandroidjetpackworkmanager/MainActivity.kt
+++ b/samples/generate-offline-map-using-android-jetpack-workmanager/src/main/java/com/esri/arcgismaps/sample/generateofflinemapusingandroidjetpackworkmanager/MainActivity.kt
@@ -152,7 +152,7 @@ class MainActivity : EdgeToEdgeCompatActivity() {
 
         // add the graphic to the graphics overlay when it is created
         graphicsOverlay.graphics.add(downloadArea)
-        // create and add a map with with portal item
+        // create and add a map with portal item
         val map = ArcGISMap(portalItem)
         // apply mapview assignments
         mapView.apply {
@@ -317,9 +317,9 @@ class MainActivity : EdgeToEdgeCompatActivity() {
                                 progressDialog.dismiss()
                             }
                         }
-                        // if the work failed or was cancelled
+                        // if the work failed or was canceled
                         WorkInfo.State.FAILED, WorkInfo.State.CANCELLED -> {
-                            // show an error message based on if it was cancelled or failed
+                            // show an error message based on if it was canceled or failed
                             if (workInfo.state == WorkInfo.State.FAILED) {
                                 showMessage("Error generating offline map")
                             } else {
@@ -392,7 +392,7 @@ class MainActivity : EdgeToEdgeCompatActivity() {
 
     /**
      * Creates a progress dialog to show the OfflineMapJob worker progress. It cancels all the
-     * running workers when the dialog is cancelled
+     * running workers when the dialog is canceled
      */
     private fun createProgressDialog(): MaterialAlertDialogBuilder {
         // build and return a new alert dialog

--- a/samples/generate-offline-map-using-android-jetpack-workmanager/src/main/java/com/esri/arcgismaps/sample/generateofflinemapusingandroidjetpackworkmanager/NotificationActionReceiver.kt
+++ b/samples/generate-offline-map-using-android-jetpack-workmanager/src/main/java/com/esri/arcgismaps/sample/generateofflinemapusingandroidjetpackworkmanager/NotificationActionReceiver.kt
@@ -11,7 +11,7 @@ import androidx.work.WorkManager
 class NotificationActionReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context?, intent: Intent?) {
-        // retrieve the data name or return if the context if null
+        // retrieve the data name or return if the context is null
         val extraName = context?.getString(R.string.notification_action) ?: return
         // get the actual data from the intent
         val action = intent?.getStringExtra(extraName) ?: "none"

--- a/samples/generate-offline-map-using-android-jetpack-workmanager/src/main/java/com/esri/arcgismaps/sample/generateofflinemapusingandroidjetpackworkmanager/OfflineJobWorker.kt
+++ b/samples/generate-offline-map-using-android-jetpack-workmanager/src/main/java/com/esri/arcgismaps/sample/generateofflinemapusingandroidjetpackworkmanager/OfflineJobWorker.kt
@@ -137,7 +137,7 @@ class OfflineJobWorker(private val context: Context, params: WorkerParameters) :
                 Result.failure()
             }
         } catch (cancellationException: CancellationException) {
-            // a CancellationException is raised if the work is cancelled manually by the user
+            // a CancellationException is raised if the work is canceled manually by the user
             // log and rethrow the cancellationException
             Log.e(javaClass.simpleName, "Offline map job canceled:", cancellationException)
             throw cancellationException

--- a/samples/generate-offline-map-with-custom-parameters/src/main/java/com/esri/arcgismaps/sample/generateofflinemapwithcustomparameters/components/GenerateOfflineMapWithCustomParametersViewModel.kt
+++ b/samples/generate-offline-map-with-custom-parameters/src/main/java/com/esri/arcgismaps/sample/generateofflinemapwithcustomparameters/components/GenerateOfflineMapWithCustomParametersViewModel.kt
@@ -214,7 +214,7 @@ class GenerateOfflineMapWithCustomParametersViewModel(private val application: A
                             it.queryOption = GenerateLayerQueryOption.UseFilter
                         }
                     }
-                    // Start a an offline map job from the task and parameters
+                    // Start an offline map job from the task and parameters
                     createOfflineMapJob(offlineMapTask, generateOfflineMapParameters, parameterOverrides)
                 }
         }
@@ -363,7 +363,7 @@ class GenerateOfflineMapWithCustomParametersViewModel(private val application: A
     }
 
     /**
-     * Helper function to get a feature layer by it's name.
+     * Helper function to get a feature layer by its name.
      */
     private fun getFeatureLayer(layerName: String): FeatureLayer? {
         return arcGISMap.operationalLayers.find { it.name == layerName } as? FeatureLayer

--- a/samples/generate-offline-map/README.md
+++ b/samples/generate-offline-map/README.md
@@ -34,7 +34,7 @@ The map used in this sample shows the [stormwater network](https://arcgisruntime
 
 ## Additional information
 
-The creation of the offline map can be fine-tuned using parameter overrides for feature layers, or by using local basemaps to achieve more customised results. Also, this sample uses the GeoView-Compose Toolkit module to be able to implement a composable MapView.
+The creation of the offline map can be fine-tuned using parameter overrides for feature layers, or by using local basemaps to achieve more customized results. Also, this sample uses the GeoView-Compose Toolkit module to be able to implement a composable MapView.
 
 ## Tags
 

--- a/samples/geocode-offline/src/main/java/com/esri/arcgismaps/sample/geocodeoffline/MainActivity.kt
+++ b/samples/geocode-offline/src/main/java/com/esri/arcgismaps/sample/geocodeoffline/MainActivity.kt
@@ -246,7 +246,7 @@ class MainActivity : EdgeToEdgeCompatActivity() {
         graphicsOverlay.graphics.add(resultLocationGraphic)
         descriptionTV.text = geocodeResultList[0].label
 
-        // get the envelop to set the viewpoint
+        // get the envelope to set the viewpoint
         val envelope = graphicsOverlay.extent ?: return showError("Geocode result extent is null")
         // animate viewpoint to geocode result's extent
         lifecycleScope.launch {

--- a/samples/identify-layer-features/src/main/java/com/esri/arcgismaps/sample/identifylayerfeatures/screens/MainScreen.kt
+++ b/samples/identify-layer-features/src/main/java/com/esri/arcgismaps/sample/identifylayerfeatures/screens/MainScreen.kt
@@ -41,7 +41,7 @@ import com.esri.arcgismaps.sample.sampleslib.components.SampleTopAppBar
  */
 @Composable
 fun MainScreen(sampleName: String) {
-    // coroutineScope that will be cancelled when this call leaves the composition
+    // coroutineScope that will be canceled when this call leaves the composition
     val sampleCoroutineScope = rememberCoroutineScope()
     // get the application property that will be used to construct MapViewModel
     val sampleApplication = LocalContext.current.applicationContext as Application

--- a/samples/manage-features/README.md
+++ b/samples/manage-features/README.md
@@ -18,10 +18,10 @@ Pick an operation, then tap on the map to perform the operation at that location
 2. Get a `ServiceFeatureTable` from the `ServiceGeodatabase`.
 3. Create a `FeatureLayer` derived from the `ServiceFeatureTable` instance.
 4. Apply the feature management operation upon tapping the map.
-    - Create features: create a `Feature` with attributes and a location using the `ServiceFeatureTable`.
-    - Delete features: delete the selected `Feature` from the `FeatureTable`.
-    - Update attribute: update the attribute of the selected `Feature`.
-    - Update geometry: update the geometry of the selected `Feature`.
+    * Create features: create a `Feature` with attributes and a location using the `ServiceFeatureTable`.
+    * Delete features: delete the selected `Feature` from the `FeatureTable`.
+    * Update attribute: update the attribute of the selected `Feature`.
+    * Update geometry: update the geometry of the selected `Feature`.
 5. Update the `FeatureTable` locally.
 6. Update the `ServiceGeodatabase` of the `ServiceFeatureTable` by calling `applyEdits()`. This pushes the changes to the server.
 

--- a/samples/manage-features/src/main/java/com/esri/arcgismaps/sample/managefeatures/components/ManageFeaturesViewModel.kt
+++ b/samples/manage-features/src/main/java/com/esri/arcgismaps/sample/managefeatures/components/ManageFeaturesViewModel.kt
@@ -126,7 +126,7 @@ class ManageFeaturesViewModel(application: Application) : AndroidViewModel(appli
     }
 
     /**
-     * Directs the behaviour of tap's on the map view.
+     * Directs the behavior of tap's on the map view.
      */
     fun onTap(singleTapConfirmedEvent: SingleTapConfirmedEvent) {
         if (damageLayer?.loadStatus?.value != LoadStatus.Loaded) {

--- a/samples/monitor-changes-to-map-load-status/README.md
+++ b/samples/monitor-changes-to-map-load-status/README.md
@@ -17,7 +17,7 @@ Click on the button to reload the ArcGISMap. The load status of the ArcGISMap wi
 The `LoadStatus` is `Loaded` when any of the following criteria are met:
 
 * The map has a valid spatial reference.
-* The map has an an initial viewpoint.
+* The map has an initial viewpoint.
 * One of the map's predefined layers has been created.
 
 ## Relevant API

--- a/samples/navigate-route-with-rerouting/src/main/java/com/esri/arcgismaps/sample/navigateroutewithrerouting/components/NavigateRouteWithReroutingViewModel.kt
+++ b/samples/navigate-route-with-rerouting/src/main/java/com/esri/arcgismaps/sample/navigateroutewithrerouting/components/NavigateRouteWithReroutingViewModel.kt
@@ -80,7 +80,7 @@ class NavigateRouteWithReroutingViewModel(application: Application) :
     // Graphics overlay to display the route ahead and traveled graphics
     val graphicsOverlay = GraphicsOverlay()
 
-    // Keep track of the the location display job when navigation is enabled
+    // Keep track of the location display job when navigation is enabled
     private var locationDisplayJob: Job? = null
 
     // Default location display object, which is updated by rememberLocationDisplay

--- a/samples/navigate-route/README.md
+++ b/samples/navigate-route/README.md
@@ -10,7 +10,7 @@ Navigation is often used by field workers while traveling between two points to 
 
 ## How to use the sample
 
-Tap 'Navigate Route' to simulate travelling and to receive directions from a preset starting point to a preset destination. Tap 'Recenter' to focus on the simulated location, or press 'Navigate Route' again to restart navigation.
+Tap 'Navigate Route' to simulate traveling and to receive directions from a preset starting point to a preset destination. Tap 'Recenter' to focus on the simulated location, or press 'Navigate Route' again to restart navigation.
 
 ## How it works
 

--- a/samples/navigate-route/src/main/java/com/esri/arcgismaps/sample/navigateroute/components/NavigateRouteViewModel.kt
+++ b/samples/navigate-route/src/main/java/com/esri/arcgismaps/sample/navigateroute/components/NavigateRouteViewModel.kt
@@ -83,7 +83,7 @@ class NavigateRouteViewModel(application: Application) : AndroidViewModel(applic
     // passed to the composable MapView to set the mapViewProxy
     val mapViewProxy = MapViewProxy()
 
-    // keep track of the the location display job when navigation is enabled
+    // keep track of the location display job when navigation is enabled
     private var locationDisplayJob: Job? = null
 
     // default location display object, which is updated by rememberLocationDisplay

--- a/samples/play-kml-tour/README.md
+++ b/samples/play-kml-tour/README.md
@@ -28,7 +28,7 @@ The sample will load the KMZ file from ArcGIS Online. When a tour is found, the 
 
 ## About the data
 
-This sample uses a custom tour from [ArcGIS Online](https://arcgisruntime.maps.arcgis.com/home/item.html?id=f10b1d37fdd645c9bc9b189fb546307c). When you play the tour, you'll go through a audio journey through some of Esri's offices.
+This sample uses a custom tour from [ArcGIS Online](https://arcgisruntime.maps.arcgis.com/home/item.html?id=f10b1d37fdd645c9bc9b189fb546307c). When you play the tour, you'll go through an audio journey through some of Esri's offices.
 
 ## Additional information
 

--- a/samples/project-geometry/README.md
+++ b/samples/project-geometry/README.md
@@ -24,7 +24,7 @@ Click anywhere on the map. A Textview will display the clicked location's coordi
 
 ## Additional information
 
-In cases where the the output spatial reference uses a different geographic coordinate system than that of the input spatial reference, see the GeometryEngine.project method that additionally takes in a DatumTransformation parameter.
+In cases where the output spatial reference uses a different geographic coordinate system than that of the input spatial reference, see the GeometryEngine.project method that additionally takes in a DatumTransformation parameter.
 
 This sample uses the GeoView-Compose Toolkit module to be able to implement a composable MapView.
 

--- a/samples/query-dynamic-entities/src/main/java/com/esri/arcgismaps/sample/querydynamicentities/components/QueryDynamicEntitiesViewModel.kt
+++ b/samples/query-dynamic-entities/src/main/java/com/esri/arcgismaps/sample/querydynamicentities/components/QueryDynamicEntitiesViewModel.kt
@@ -65,6 +65,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlin.math.cos
 import kotlin.math.sin
+import kotlin.time.Duration.Companion.milliseconds
 
 class QueryDynamicEntitiesViewModel(application: Application) : AndroidViewModel(application) {
 
@@ -326,7 +327,7 @@ private class PlaneFeedProvider : CustomDynamicEntityDataSource.EntityFeedProvid
                             )
                         )
                     }
-                    delay(1000)
+                    delay(1000.milliseconds)
                 }
             } catch (e: Exception) {
                 if (e is CancellationException) throw e

--- a/samples/query-feature-table/src/main/java/com/esri/arcgismaps/sample/queryfeaturetable/screens/MainScreen.kt
+++ b/samples/query-feature-table/src/main/java/com/esri/arcgismaps/sample/queryfeaturetable/screens/MainScreen.kt
@@ -37,7 +37,7 @@ import com.esri.arcgismaps.sample.sampleslib.components.SampleTopAppBar
  */
 @Composable
 fun MainScreen(sampleName: String) {
-    // coroutineScope that will be cancelled when this call leaves the composition
+    // coroutineScope that will be canceled when this call leaves the composition
     val sampleCoroutineScope = rememberCoroutineScope()
     // get the application context
     val application = LocalContext.current.applicationContext as Application

--- a/samples/query-features-with-arcade-expression/README.md
+++ b/samples/query-features-with-arcade-expression/README.md
@@ -17,7 +17,7 @@ Tap on any neighborhood to see the number of crimes in the last 60 days in a Tex
 1. Create a `PortalItem` using the URL and ID.
 2. Create an `ArcGISMap` using the portal item.
 3. Create a `MapViewProxy` to handle user interaction with the map view.
-4. Provide behaviour for the `MapView`'s `onSingleTapConfirmed` parameter to react to taps on the map.
+4. Provide behavior for the `MapView`'s `onSingleTapConfirmed` parameter to react to taps on the map.
 5. Identify the visible layer where it is tapped using `mapViewProxy.identify()` and get the feature from the result.
 6. Create the following `ArcadeExpression`:
 

--- a/samples/query-features-with-arcade-expression/src/main/java/com/esri/arcgismaps/sample/queryfeatureswitharcadeexpression/components/QueryFeaturesWithArcadeExpressionViewModel.kt
+++ b/samples/query-features-with-arcade-expression/src/main/java/com/esri/arcgismaps/sample/queryfeatureswitharcadeexpression/components/QueryFeaturesWithArcadeExpressionViewModel.kt
@@ -114,7 +114,7 @@ class QueryFeaturesWithArcadeExpressionViewModel(application: Application) :
         // update the marker location to where the user tapped on the map
         markerGraphic.geometry = point
         viewModelScope.launch {
-            // centre the viewpoint on where the user tapped on the map
+            // center the viewpoint on where the user tapped on the map
             mapViewProxy.setViewpointCenter(point)
 
             // evaluate an Arcade expression on the tapped screen coordinate

--- a/samples/search-with-geocode/src/main/java/com/esri/arcgismaps/sample/searchwithgeocode/MainActivity.kt
+++ b/samples/search-with-geocode/src/main/java/com/esri/arcgismaps/sample/searchwithgeocode/MainActivity.kt
@@ -301,7 +301,7 @@ class MainActivity : EdgeToEdgeCompatActivity() {
             else -> addressTextView.text = getString(R.string.tap_on_pin_to_select_address)
         }
 
-        // get the envelop to set the viewpoint
+        // get the envelope to set the viewpoint
         val envelope = graphicsOverlay.extent ?: return showError("Geocode result extent is null")
         // animate viewpoint to geocode result's extent
         lifecycleScope.launch {

--- a/samples/set-max-extent/README.md
+++ b/samples/set-max-extent/README.md
@@ -18,7 +18,7 @@ by the max extent. Use the toggle switch to disable the max extent to freely pan
 ## How it works
 
 1. Create an `ArcGISMap` object.
-2. Create an envelop of the extent using `Envelope(Point(x, y), Point(x, y))`
+2. Create an envelope of the extent using `Envelope(Point(x, y), Point(x, y))`
 3. Set the maximum extent of the map with `map.maxExtent = envelope`.
 4. Set the map to a `MapView` object.
 5. Set `map.maxExtent = null` to disable the maximum extent of the map

--- a/samples/set-up-location-driven-geotriggers/src/main/java/com/esri/arcgismaps/sample/setuplocationdrivengeotriggers/MainActivity.kt
+++ b/samples/set-up-location-driven-geotriggers/src/main/java/com/esri/arcgismaps/sample/setuplocationdrivengeotriggers/MainActivity.kt
@@ -70,7 +70,7 @@ class MainActivity : EdgeToEdgeCompatActivity() {
         activityMainBinding.sectionButton
     }
 
-    // recycler list view to show the the points of interest
+    // recycler list view to show the points of interest
     private val poiListView by lazy {
         activityMainBinding.poiListView
     }

--- a/samples/show-exploratory-viewshed-from-point-in-scene/src/main/java/com/esri/arcgismaps/sample/showexploratoryviewshedfrompointinscene/MainActivity.kt
+++ b/samples/show-exploratory-viewshed-from-point-in-scene/src/main/java/com/esri/arcgismaps/sample/showexploratoryviewshedfrompointinscene/MainActivity.kt
@@ -22,7 +22,6 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.runtime.Composable
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
 import com.esri.arcgismaps.sample.showexploratoryviewshedfrompointinscene.screens.MainScreen
 

--- a/samples/show-interactive-viewshed-with-analysis-overlay/README.md
+++ b/samples/show-interactive-viewshed-with-analysis-overlay/README.md
@@ -12,7 +12,7 @@ Note: This analysis is a form of "data-driven analysis", which means the analysi
 
 ## How to use the sample
 
-The sample loads with a viewshed analysis initialized from an elevation raster covering the Isle of Arran, Scotland. Translucent green shows the area visible from the observer position, and grey shows the non-visible areas. Move the observer position by long-pressing and dragging over the island to interactively evaluate the viewshed result and display it in the analysis overlay. Alternatively, tap on the map to see the viewshed from the tapped location. Use the sliders and radio buttons to explore how the viewshed analysis results change when adjusting the observer elevation, target height, maximum radius, field of view, heading and elevation sampling interval. As you move the observer and update the viewshed parameters, the analysis overlay refreshes to show the evaluated viewshed result.
+The sample loads with a viewshed analysis initialized from an elevation raster covering the Isle of Arran, Scotland. Translucent green shows the area visible from the observer position, and gray shows the non-visible areas. Move the observer position by long-pressing and dragging over the island to interactively evaluate the viewshed result and display it in the analysis overlay. Alternatively, tap on the map to see the viewshed from the tapped location. Use the sliders and radio buttons to explore how the viewshed analysis results change when adjusting the observer elevation, target height, maximum radius, field of view, heading and elevation sampling interval. As you move the observer and update the viewshed parameters, the analysis overlay refreshes to show the evaluated viewshed result.
 
 ## How it works
 

--- a/samples/show-labels-on-layer/src/main/java/com/esri/arcgismaps/sample/showlabelsonlayer/MainActivity.kt
+++ b/samples/show-labels-on-layer/src/main/java/com/esri/arcgismaps/sample/showlabelsonlayer/MainActivity.kt
@@ -112,7 +112,7 @@ class MainActivity : EdgeToEdgeCompatActivity() {
             haloColor = Color.white
             haloWidth = 2f
         }
-        // create a arcade label expression for the label text
+        // create an arcade label expression for the label text
         val arcadeLabelExpression =
             ArcadeLabelExpression(
                 "\$feature.NAME + \" (\" + left(\$feature.PARTY,1) " +

--- a/samples/snap-geometry-edits-with-utility-network-rules/README.md
+++ b/samples/snap-geometry-edits-with-utility-network-rules/README.md
@@ -10,7 +10,7 @@ A field worker can create new features in a utility network by editing and snapp
 
 ## How to use the sample
 
-To edit a geometry, tap a point geometry to be edited in the map to select it. Then edit the geometry by tapping the button to start the geometry edito with the reticle tool.
+To edit a geometry, tap a point geometry to be edited in the map to select it. Then edit the geometry by tapping the button to start the geometry editor with the reticle tool.
 
 Snap sources can be enabled and disabled. Snapping will not occur when `SnapRuleBehavior.RulesPreventSnapping` even when the source is enabled.
 

--- a/samples/snap-geometry-edits/src/main/java/com/esri/arcgismaps/sample/snapgeometryedits/components/SnapGeometryEditsViewModel.kt
+++ b/samples/snap-geometry-edits/src/main/java/com/esri/arcgismaps/sample/snapgeometryedits/components/SnapGeometryEditsViewModel.kt
@@ -50,7 +50,7 @@ class SnapGeometryEditsViewModel(
     // create a map using the URL of the web map
     val map = ArcGISMap(application.getString(R.string.web_map))
 
-    // create a graphic, graphic overlay, and geometry editorenc
+    // create a graphic, graphic overlay, and geometry editor
     private var identifiedGraphic = Graphic()
     val graphicsOverlay = GraphicsOverlay()
     val geometryEditor = GeometryEditor()
@@ -117,14 +117,14 @@ class SnapGeometryEditsViewModel(
     }
 
     /**
-     * Synchronises the snap source collection with the map's operational layers, sets the bottom
+     * Synchronizes the snap source collection with the map's operational layers, sets the bottom
      * sheet UI, and shows it to configure snapping.
      */
     fun showBottomSheet() {
         if (geometryEditor.snapSettings.sourceSettings.isEmpty()) {
             // sync the snap source collection
             geometryEditor.snapSettings.syncSourceSettings()
-            // initialise the snap source lists used for the bottom sheet
+            // initialize the snap source lists used for the bottom sheet
             geometryEditor.snapSettings.sourceSettings.forEach { snapSource ->
                 snapSourceCheckedState.add(snapSource.isEnabled)
             }

--- a/samples/snap-geometry-edits/src/main/java/com/esri/arcgismaps/sample/snapgeometryedits/screens/SnapGeometryEditsScreen.kt
+++ b/samples/snap-geometry-edits/src/main/java/com/esri/arcgismaps/sample/snapgeometryedits/screens/SnapGeometryEditsScreen.kt
@@ -42,7 +42,7 @@ import com.esri.arcgismaps.sample.snapgeometryedits.components.SnapGeometryEdits
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MainScreen(sampleName: String) {
-    // coroutineScope that will be cancelled when this call leaves the composition
+    // coroutineScope that will be canceled when this call leaves the composition
     val sampleCoroutineScope = rememberCoroutineScope()
     // get the application property that will be used to construct MapViewModel
     val sampleApplication = LocalContext.current.applicationContext as Application

--- a/samples/trace-utility-network/src/main/java/com/esri/arcgismaps/sample/traceutilitynetwork/components/TraceUtilityNetworkViewModel.kt
+++ b/samples/trace-utility-network/src/main/java/com/esri/arcgismaps/sample/traceutilitynetwork/components/TraceUtilityNetworkViewModel.kt
@@ -156,9 +156,8 @@ class TraceUtilityNetworkViewModel(application: Application) : AndroidViewModel(
      */
     private fun getAuthenticationChallengeHandler(): ArcGISAuthenticationChallengeHandler {
         return ArcGISAuthenticationChallengeHandler { challenge ->
-            val result: Result<TokenCredential> = runBlocking {
+            val result: Result<TokenCredential> =
                 TokenCredential.create(challenge.requestUrl, "viewer01", "I68VGU^nMurF", 0)
-            }
             if (result.getOrNull() != null) {
                 val credential = result.getOrNull()
                 return@ArcGISAuthenticationChallengeHandler ArcGISAuthenticationChallengeResponse.ContinueWithCredential(

--- a/samples/trace-utility-network/src/main/java/com/esri/arcgismaps/sample/traceutilitynetwork/components/TraceUtilityNetworkViewModel.kt
+++ b/samples/trace-utility-network/src/main/java/com/esri/arcgismaps/sample/traceutilitynetwork/components/TraceUtilityNetworkViewModel.kt
@@ -60,7 +60,6 @@ import com.esri.arcgismaps.sample.sampleslib.components.MessageDialogViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlin.math.roundToLong
 
 class TraceUtilityNetworkViewModel(application: Application) : AndroidViewModel(application) {

--- a/samples/validate-utility-network-topology/src/main/java/com/esri/arcgismaps/sample/validateutilitynetworktopology/components/ValidateUtilityNetworkTopologyViewModel.kt
+++ b/samples/validate-utility-network-topology/src/main/java/com/esri/arcgismaps/sample/validateutilitynetworktopology/components/ValidateUtilityNetworkTopologyViewModel.kt
@@ -68,7 +68,6 @@ import com.esri.arcgismaps.sample.validateutilitynetworktopology.components.Vali
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import java.util.UUID
 
 class ValidateUtilityNetworkTopologyViewModel(application: Application) :

--- a/samples/validate-utility-network-topology/src/main/java/com/esri/arcgismaps/sample/validateutilitynetworktopology/components/ValidateUtilityNetworkTopologyViewModel.kt
+++ b/samples/validate-utility-network-topology/src/main/java/com/esri/arcgismaps/sample/validateutilitynetworktopology/components/ValidateUtilityNetworkTopologyViewModel.kt
@@ -643,9 +643,8 @@ class ValidateUtilityNetworkTopologyViewModel(application: Application) :
  */
 private fun getAuthChallengeHandler(): ArcGISAuthenticationChallengeHandler {
     return ArcGISAuthenticationChallengeHandler { challenge ->
-        val result: Result<TokenCredential> = runBlocking {
+        val result: Result<TokenCredential> =
             TokenCredential.create(challenge.requestUrl, USERNAME, PASSWORD, 0)
-        }
         if (result.getOrNull() != null) {
             val credential = result.getOrNull()
             return@ArcGISAuthenticationChallengeHandler ArcGISAuthenticationChallengeResponse

--- a/samples/validate-utility-network-topology/src/main/java/com/esri/arcgismaps/sample/validateutilitynetworktopology/components/ValidateUtilityNetworkTopologyViewModel.kt
+++ b/samples/validate-utility-network-topology/src/main/java/com/esri/arcgismaps/sample/validateutilitynetworktopology/components/ValidateUtilityNetworkTopologyViewModel.kt
@@ -300,7 +300,7 @@ class ValidateUtilityNetworkTopologyViewModel(application: Application) :
      * Adds labels for a given field name to a layer with a given name.
      */
     private fun addLabels(layerName: String, fieldName: String, textColor: Color) {
-        // Create a expression for the label using the given field name
+        // Create an expression for the label using the given field name
         val expression = SimpleLabelExpression(simpleExpression = "[$fieldName]")
         // Create a symbol for label's text using the given color
         val symbol = TextSymbol().apply {
@@ -375,7 +375,7 @@ class ValidateUtilityNetworkTopologyViewModel(application: Application) :
 
     /**
      * Identify a single feature from the [screenCoordinate], check if belongs to the
-     * device or line layer, get the coded-value domain from it's field to allow editing.
+     * device or line layer, get the coded-value domain from its field to allow editing.
      */
     fun identifyFeatureAt(
         screenCoordinate: ScreenCoordinate,

--- a/tools/CI/README_Metadata_StyleCheck/README.md
+++ b/tools/CI/README_Metadata_StyleCheck/README.md
@@ -1,0 +1,109 @@
+# README and Metadata Style Checks
+
+This folder contains the Docker-based checker used by GitHub Actions to validate sample documentation in this repository.
+
+The action is wired through [action.yml](action.yml) and runs automatically in CI for changed sample documentation files. The container entrypoint executes:
+
+* `mdl` for Markdown linting of sample `README.md` files
+* `README_style_checker.py` for sample README structure and title rules
+* `metadata_style_checker.py` for sample `README.metadata.json` validation
+
+The current action scope is limited to files under `samples/` named `README.md` or `README.metadata.json`.
+
+Use this README to run the same checks locally before pushing changes.
+
+## Prerequisites
+
+For local usage:
+
+* Docker Desktop or another working Docker runtime
+* Git
+* Python 3 available on the host shell for building the JSON file list passed into Docker
+* Run commands from anywhere inside this repository
+* For diff-based commands, make sure the comparison branch exists locally, for example:
+
+```bash
+git fetch origin v.next
+```
+
+Build the checker image before running the examples below:
+
+```bash
+docker build -t readme-metadata-stylecheck \
+  -f tools/CI/README_Metadata_StyleCheck/Dockerfile.dockerfile \
+  tools/CI/README_Metadata_StyleCheck
+```
+
+Rebuild the image any time files are changed in this folder, such as `entry.py`, `README_style_checker.py`, `metadata_style_checker.py`, or `style.rb`.
+
+## Example 1: Check the Current Sample Folder
+
+Use this when already inside a specific sample folder such as `samples/show-line-of-sight-analysis-in-map/`.
+
+This command detects the current sample directory, collects `README.md` and `README.metadata.json` if present, and runs both checkers in Docker using the repository root as the mounted workspace.
+
+```bash
+repo_root=$(git rev-parse --show-toplevel) && \
+sample_dir=$(python3 -c 'import os,sys; print(os.path.relpath(os.getcwd(), sys.argv[1]))' "$repo_root") && \
+file_list=$(python3 -c 'import json,os,sys; sample_dir,repo_root=sys.argv[1:3]; candidates=[f"{sample_dir}/README.md", f"{sample_dir}/README.metadata.json"]; print(json.dumps([path for path in candidates if os.path.exists(os.path.join(repo_root, path))]))' "$sample_dir" "$repo_root") && \
+docker run --rm -v "$repo_root":/github/workspace -w /github/workspace \
+  readme-metadata-stylecheck \
+  --string "$file_list"
+```
+
+Expected result: the command exits with code `0` when both the README and metadata checks pass for the current sample.
+
+## Example 2: Check Current Branch Diffs and Local Doc Edits
+
+Use this to simulate what CI would check for sample docs changed against `origin/v.next`, while also including local staged and unstaged README or metadata edits.
+
+```bash
+repo_root=$(git rev-parse --show-toplevel) && \
+cd "$repo_root" && \
+changed_docs=$( \
+  { \
+    git diff --name-only origin/v.next...HEAD -- \
+      'samples/**/README.md' \
+      'samples/**/README.metadata.json'; \
+    git diff --name-only --cached -- \
+      'samples/**/README.md' \
+      'samples/**/README.metadata.json'; \
+    git diff --name-only -- \
+      'samples/**/README.md' \
+      'samples/**/README.metadata.json'; \
+  } | awk 'NF' | sort -u \
+    | python3 -c 'import json,sys; print(json.dumps([line.strip() for line in sys.stdin if line.strip()]))' \
+) && \
+echo "$changed_docs" && \
+docker run --rm -v "$repo_root":/github/workspace -w /github/workspace \
+  readme-metadata-stylecheck \
+  --string "$changed_docs"
+```
+
+Expected result: the command prints the exact sample doc files that will be checked, then exits with code `0` if they all pass.
+
+## Example 3: Check All Samples
+
+Use this for a full repository sweep of every sample README and metadata file, regardless of current git diffs.
+
+```bash
+repo_root=$(git rev-parse --show-toplevel) && \
+cd "$repo_root" && \
+all_sample_docs=$( \
+  find samples -type f \( -name 'README.md' -o -name 'README.metadata.json' \) \
+  | LC_ALL=C sort \
+  | python3 -c 'import json,sys; print(json.dumps([line.strip() for line in sys.stdin if line.strip()]))' \
+) && \
+echo "$all_sample_docs" && \
+docker run --rm -v "$repo_root":/github/workspace -w /github/workspace \
+  readme-metadata-stylecheck \
+  --string "$all_sample_docs"
+```
+
+Expected result: the command performs a full documentation sweep across all samples and exits with code `0` only if all README and metadata files pass.
+
+## Notes
+
+* Running `entry.py` directly on the host is not the intended local workflow. It expects container paths such as `/README_style_checker.py` and `/style.rb`.
+* The Docker workflow above is the closest local match to GitHub Actions behavior.
+* The diff-based command is intentionally scoped to sample `README.md` and `README.metadata.json` files because that is the only content this action evaluates.

--- a/tools/CI/README_Metadata_StyleCheck/README_style_checker.py
+++ b/tools/CI/README_Metadata_StyleCheck/README_style_checker.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-from ast import Tuple
 import os
 import re
 import typing
@@ -9,28 +8,22 @@ import argparse
 # region Global sets
 # A set of words that get omitted during letter-case checks.
 exception_proper_nouns = {
-    'Arcade'
-    'WmsLayer',
+    'Arcade',
+    'Android',
     'ArcGIS Online',
+    'ArcGIS Pro',
+    'Jetpack',
+    'MapView',
     'OAuth',
     'Web Mercator',
-    'ArcGIS Pro',
-    'GeoPackage',
-    'loadStatus',
-    'Integrated Windows Authentication',
-    'GeoElement',
-    'Network Link',
-    'Network Link Control',
-    'Open Street Map',
-    'OpenStreetMap',
-    'Play a KML Tour'
+    'WorkManager'
 }
 
 # endregion
 
 
 # region Static functions
-def parse_head(head_string: str) -> (str, str):
+def parse_head(head_string: str) -> typing.Tuple[str, str]:
     """
     Parse the head of README and get title and description.
 

--- a/tools/CI/README_Metadata_StyleCheck/entry.py
+++ b/tools/CI/README_Metadata_StyleCheck/entry.py
@@ -47,6 +47,17 @@ def read_json(filenames_json_data):
     return [filename for filename in filenames_json_data]
 
 
+def is_sample_doc_path(path: str) -> bool:
+    normalized_path = os.path.normpath(path)
+    path_parts = normalized_path.split(os.path.sep)
+
+    if not path_parts or path_parts[0] != 'samples':
+        return False
+
+    filename = os.path.basename(normalized_path).lower()
+    return filename == 'readme.md' or filename == 'readme.metadata.json'
+
+
 def load_json_file(path: str):
     try:
         json_file = open(path, 'r')
@@ -88,14 +99,13 @@ def main():
             print("Note: This file has since been deleted. No style check will be performed on: " + f)
             continue
         
+        if not is_sample_doc_path(f):
+            continue
+
         # Get filename and folder name of the changed sample.
         filename = os.path.basename(f)
         dir_path = os.path.dirname(f)
         l_name = filename.lower()
-
-        # Changed file is not a README or metadata file, omit.
-        if l_name != 'readme.md' and l_name != 'readme.metadata.json':
-            continue
 
         # Print debug information for current sample.
         if dir_path not in samples_set:
@@ -115,8 +125,8 @@ def main():
             # Run the linter on markdown file.
             return_code += run_mdl(f)
 
-        # Run the other Python checks on the whole sample folder.
-        if dir_path not in samples_set:
+        # Run the other Python checks on sample folders only.
+        if dir_path and dir_path not in samples_set:
             samples_set.add(dir_path)
             return_code += run_style_check(dir_path)
 

--- a/tools/CI/README_Metadata_StyleCheck/metadata_style_checker.py
+++ b/tools/CI/README_Metadata_StyleCheck/metadata_style_checker.py
@@ -307,8 +307,8 @@ def compare_one_metadata(folder_path: str):
     if json_data['description'] in sub_special_char(single_updater.description):
         single_updater.description = json_data['description']
     # The special rule to ignore the order of src filenames.
-    # If the original json has all the filenames, then it is good.
-    if sorted(json_data['snippets']) == single_updater.snippets:
+    # If the original json contains the same snippet paths, preserve its order.
+    if sorted(json_data['snippets']) == sorted(single_updater.snippets):
         single_updater.snippets = json_data['snippets']
 
     new = single_updater.flush_to_json_string()


### PR DESCRIPTION
## Description

PR to prepare the Kotlin samples project for `v300.1` release. 

Changes made:

- Run `Inspect code` to apply warnings based on the level of importance, this PR addresses Kotlin code warnings and generic grammar proofreading. 

- Bug fixes applied to Git checkers to now:
  - Not enforce deterministic snippet ordering, to rather ensure all `.kt` files are available.
  - Include keyword nouns of sample titles using capital case, and remove those which aren't supported (legacy). 
  - Ignore all `.md` files which do not lie within `samples/` folder, which will allow the root readme to be ignored to aim to get a clean Git action pass for the release PR ([past release](https://github.com/Esri/arcgis-maps-sdk-kotlin-samples/pull/473)).


## Links and Data

Sample Epic: `runtime/kotlin/issues/7955`
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/Release/job/300.1.0/job/vtest/job/sampleviewer/3/
