### PR TITLE
Show dialog on AnalysisViewStatus.Error

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 # ArcGIS Maps SDK for Kotlin version
-arcgisMapsKotlinVersion = "300.1.0-5024"
+arcgisMapsKotlinVersion = "300.1.0-5033"
 
 ### Android versions
 androidGradlePlugin = "9.2.1"

--- a/samples/analyze-terrain-suitability-from-slope-and-aspect/src/main/java/com/esri/arcgismaps/sample/analyzeterrainsuitabilityfromslopeandaspect/components/AnalyzeTerrainSuitabilityFromSlopeAndAspectViewModel.kt
+++ b/samples/analyze-terrain-suitability-from-slope-and-aspect/src/main/java/com/esri/arcgismaps/sample/analyzeterrainsuitabilityfromslopeandaspect/components/AnalyzeTerrainSuitabilityFromSlopeAndAspectViewModel.kt
@@ -245,6 +245,7 @@ class AnalyzeTerrainSuitabilityFromSlopeAndAspectViewModel(app: Application) :
     /**
      * An AnalysisViewStatus listener that displays the progress indicator when the status of the
      * current scenario analysis is Updating and hides it when not Updating.
+     * Also displays details of any error that occurs when the analysis is displayed.
      */
     fun analysisViewStatusListener(event: GeoView.GeoViewAnalysisViewStatusChanged) {
         displayProgressIndicator = when (event.analysisViewStatus){

--- a/samples/analyze-terrain-suitability-from-slope-and-aspect/src/main/java/com/esri/arcgismaps/sample/analyzeterrainsuitabilityfromslopeandaspect/components/AnalyzeTerrainSuitabilityFromSlopeAndAspectViewModel.kt
+++ b/samples/analyze-terrain-suitability-from-slope-and-aspect/src/main/java/com/esri/arcgismaps/sample/analyzeterrainsuitabilityfromslopeandaspect/components/AnalyzeTerrainSuitabilityFromSlopeAndAspectViewModel.kt
@@ -247,12 +247,19 @@ class AnalyzeTerrainSuitabilityFromSlopeAndAspectViewModel(app: Application) :
      * current scenario analysis is Updating and hides it when not Updating.
      */
     fun analysisViewStatusListener(event: GeoView.GeoViewAnalysisViewStatusChanged) {
-        val currentScenarioAnalysis = when (adaptiveUiState.value.scenarioOption) {
-            ScenarioOption.Sheltered -> shelteredSlopesAnalysis
-            ScenarioOption.Exposed -> exposedSlopesAnalysis
-        }
-        if (event.analysis == currentScenarioAnalysis) {
-            displayProgressIndicator = event.analysisViewStatus == AnalysisViewStatus.Updating
+        displayProgressIndicator = when (event.analysisViewStatus){
+            is AnalysisViewStatus.Error -> {
+                messageDialogVM.showMessageDialog(
+                    throwable = (event.analysisViewStatus as AnalysisViewStatus.Error).details
+                )
+                false
+            }
+            AnalysisViewStatus.UpToDate -> {
+                false
+            }
+            AnalysisViewStatus.Updating -> {
+                true
+            }
         }
     }
 

--- a/samples/show-exploratory-line-of-sight-between-geoelements/src/main/java/com/esri/arcgismaps/sample/showexploratorylineofsightbetweengeoelements/components/SceneViewModel.kt
+++ b/samples/show-exploratory-line-of-sight-between-geoelements/src/main/java/com/esri/arcgismaps/sample/showexploratorylineofsightbetweengeoelements/components/SceneViewModel.kt
@@ -45,10 +45,13 @@ import com.arcgismaps.mapping.symbology.SimpleMarkerSymbol
 import com.arcgismaps.mapping.symbology.SimpleMarkerSymbolStyle
 import com.arcgismaps.mapping.symbology.SimpleRenderer
 import com.arcgismaps.mapping.view.AnalysisOverlay
+import com.arcgismaps.mapping.view.AnalysisViewStatus
 import com.arcgismaps.mapping.view.Camera
+import com.arcgismaps.mapping.view.GeoView
 import com.arcgismaps.mapping.view.Graphic
 import com.arcgismaps.mapping.view.GraphicsOverlay
 import com.arcgismaps.mapping.view.SurfacePlacement
+import com.esri.arcgismaps.sample.sampleslib.components.MessageDialogViewModel
 import com.esri.arcgismaps.sample.showexploratorylineofsightbetweengeoelements.R
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -59,6 +62,9 @@ import java.io.File
 import kotlin.concurrent.timer
 
 class SceneViewModel(private var application: Application) : AndroidViewModel(application) {
+
+    // Message dialog view model to display errors
+    val messageDialogVM = MessageDialogViewModel()
 
     // Keep track of target visibility status string state.
     var targetVisibilityString by mutableStateOf("")
@@ -275,4 +281,14 @@ class SceneViewModel(private var application: Application) : AndroidViewModel(ap
         }
     }
 
+    /**
+     * Display dialog if there is an error with analysis.
+     */
+    fun analysisViewStatusListener(event: GeoView.GeoViewAnalysisViewStatusChanged) {
+        if (event.analysisViewStatus is AnalysisViewStatus.Error) {
+            messageDialogVM.showMessageDialog(
+                throwable = (event.analysisViewStatus as AnalysisViewStatus.Error).details
+            )
+        }
+    }
 }

--- a/samples/show-exploratory-line-of-sight-between-geoelements/src/main/java/com/esri/arcgismaps/sample/showexploratorylineofsightbetweengeoelements/screens/MainScreen.kt
+++ b/samples/show-exploratory-line-of-sight-between-geoelements/src/main/java/com/esri/arcgismaps/sample/showexploratorylineofsightbetweengeoelements/screens/MainScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.arcgismaps.toolkit.geoviewcompose.SceneView
+import com.esri.arcgismaps.sample.sampleslib.components.MessageDialog
 import com.esri.arcgismaps.sample.sampleslib.components.SampleTopAppBar
 import com.esri.arcgismaps.sample.showexploratorylineofsightbetweengeoelements.components.SceneViewModel
 
@@ -84,7 +85,8 @@ fun MainScreen(sampleName: String) {
                         .weight(1f),
                     arcGISScene = sceneViewModel.scene,
                     analysisOverlays = listOf(sceneViewModel.analysisOverlay),
-                    graphicsOverlays = listOf(sceneViewModel.graphicsOverlay)
+                    graphicsOverlays = listOf(sceneViewModel.graphicsOverlay),
+                    onAnalysisViewStatusChanged = sceneViewModel::analysisViewStatusListener
                 )
 
                 // Composable function that holds the slider and the text position value
@@ -108,6 +110,16 @@ fun MainScreen(sampleName: String) {
                         },
                     )
 
+                }
+            }
+            // Display a dialog if the sample encounters an error
+            sceneViewModel.messageDialogVM.apply {
+                if (dialogStatus) {
+                    MessageDialog(
+                        title = messageTitle,
+                        description = messageDescription,
+                        onDismissRequest = ::dismissDialog
+                    )
                 }
             }
         })

--- a/samples/show-exploratory-viewshed-from-point-in-scene/src/main/java/com/esri/arcgismaps/sample/showexploratoryviewshedfrompointinscene/components/SceneViewModel.kt
+++ b/samples/show-exploratory-viewshed-from-point-in-scene/src/main/java/com/esri/arcgismaps/sample/showexploratoryviewshedfrompointinscene/components/SceneViewModel.kt
@@ -31,8 +31,11 @@ import com.arcgismaps.mapping.Surface
 import com.arcgismaps.mapping.Viewpoint
 import com.arcgismaps.mapping.layers.ArcGISSceneLayer
 import com.arcgismaps.mapping.view.AnalysisOverlay
+import com.arcgismaps.mapping.view.AnalysisViewStatus
 import com.arcgismaps.mapping.view.Camera
+import com.arcgismaps.mapping.view.GeoView
 import com.arcgismaps.toolkit.geoviewcompose.SceneViewProxy
+import com.esri.arcgismaps.sample.sampleslib.components.MessageDialogViewModel
 import com.esri.arcgismaps.sample.showexploratoryviewshedfrompointinscene.R
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -84,6 +87,9 @@ class SceneViewModel(private val application: Application) : AndroidViewModel(ap
     val viewshedUiState = _viewshedUiState.asStateFlow()
 
     val sceneViewProxy = SceneViewProxy()
+
+    // Message dialog view model to display errors
+    val messageDialogVM = MessageDialogViewModel()
 
 
     init {
@@ -200,6 +206,17 @@ class SceneViewModel(private val application: Application) : AndroidViewModel(ap
                     roll = 0.0
                 ),
                 duration = 2.seconds
+            )
+        }
+    }
+
+    /**
+     * Display dialog if there is an error with analysis.
+     */
+    fun analysisViewStatusListener(event: GeoView.GeoViewAnalysisViewStatusChanged) {
+        if (event.analysisViewStatus is AnalysisViewStatus.Error) {
+            messageDialogVM.showMessageDialog(
+                throwable = (event.analysisViewStatus as AnalysisViewStatus.Error).details
             )
         }
     }

--- a/samples/show-exploratory-viewshed-from-point-in-scene/src/main/java/com/esri/arcgismaps/sample/showexploratoryviewshedfrompointinscene/components/SceneViewModel.kt
+++ b/samples/show-exploratory-viewshed-from-point-in-scene/src/main/java/com/esri/arcgismaps/sample/showexploratoryviewshedfrompointinscene/components/SceneViewModel.kt
@@ -91,7 +91,6 @@ class SceneViewModel(private val application: Application) : AndroidViewModel(ap
     // Message dialog view model to display errors
     val messageDialogVM = MessageDialogViewModel()
 
-
     init {
         // create a surface for elevation data
         val surface = Surface().apply {

--- a/samples/show-exploratory-viewshed-from-point-in-scene/src/main/java/com/esri/arcgismaps/sample/showexploratoryviewshedfrompointinscene/screens/MainScreen.kt
+++ b/samples/show-exploratory-viewshed-from-point-in-scene/src/main/java/com/esri/arcgismaps/sample/showexploratoryviewshedfrompointinscene/screens/MainScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.arcgismaps.toolkit.geoviewcompose.SceneView
+import com.esri.arcgismaps.sample.sampleslib.components.MessageDialog
 import com.esri.arcgismaps.sample.sampleslib.components.adaptive.AdaptiveThreePane
 import com.esri.arcgismaps.sample.sampleslib.components.SampleDeviceLightDarkPreview
 import com.esri.arcgismaps.sample.sampleslib.components.SamplePreviewSurface
@@ -64,8 +65,19 @@ fun MainScreen() {
                     .animateContentSize(),
                 arcGISScene = sceneViewModel.scene,
                 sceneViewProxy = sceneViewModel.sceneViewProxy,
-                analysisOverlays = listOf(sceneViewModel.analysisOverlay)
+                analysisOverlays = listOf(sceneViewModel.analysisOverlay),
+                onAnalysisViewStatusChanged = sceneViewModel::analysisViewStatusListener
             )
+            // Show a message dialog if the viewmodel reported an error
+            sceneViewModel.messageDialogVM.apply {
+                if (dialogStatus) {
+                    MessageDialog(
+                        title = messageTitle,
+                        description = messageDescription,
+                        onDismissRequest = ::dismissDialog
+                    )
+                }
+            }
         }
     )
 }

--- a/samples/show-interactive-viewshed-with-analysis-overlay/src/main/java/com/esri/arcgismaps/sample/showinteractiveviewshedwithanalysisoverlay/components/ShowInteractiveViewshedWithAnalysisOverlayViewModel.kt
+++ b/samples/show-interactive-viewshed-with-analysis-overlay/src/main/java/com/esri/arcgismaps/sample/showinteractiveviewshedwithanalysisoverlay/components/ShowInteractiveViewshedWithAnalysisOverlayViewModel.kt
@@ -38,6 +38,8 @@ import com.arcgismaps.mapping.symbology.SimpleMarkerSymbolStyle
 import com.arcgismaps.mapping.symbology.raster.Colormap
 import com.arcgismaps.mapping.symbology.raster.ColormapRenderer
 import com.arcgismaps.mapping.view.AnalysisOverlay
+import com.arcgismaps.mapping.view.AnalysisViewStatus
+import com.arcgismaps.mapping.view.GeoView
 import com.arcgismaps.mapping.view.Graphic
 import com.arcgismaps.mapping.view.GraphicsOverlay
 import com.arcgismaps.mapping.view.LongPressEvent
@@ -283,6 +285,17 @@ class ShowInteractiveViewshedWithAnalysisOverlayViewModel(app: Application) : An
 
         // Update the viewshed parameters to the current observer position, which triggers analysis
         viewshedParameters.observerPosition = observerPosition
+    }
+
+    /**
+     * Display dialog if there is an error with analysis.
+     */
+    fun analysisViewStatusListener(event: GeoView.GeoViewAnalysisViewStatusChanged) {
+        if (event.analysisViewStatus is AnalysisViewStatus.Error) {
+            messageDialogVM.showMessageDialog(
+                throwable = (event.analysisViewStatus as AnalysisViewStatus.Error).details
+            )
+        }
     }
 }
 

--- a/samples/show-interactive-viewshed-with-analysis-overlay/src/main/java/com/esri/arcgismaps/sample/showinteractiveviewshedwithanalysisoverlay/screens/ShowInteractiveViewshedWithAnalysisOverlayScreen.kt
+++ b/samples/show-interactive-viewshed-with-analysis-overlay/src/main/java/com/esri/arcgismaps/sample/showinteractiveviewshedwithanalysisoverlay/screens/ShowInteractiveViewshedWithAnalysisOverlayScreen.kt
@@ -83,6 +83,7 @@ fun ShowInteractiveViewshedWithAnalysisOverlayScreen() {
                     onSingleTapConfirmed = viewModel::onTap,
                     onLongPress = viewModel::onLongPress,
                     onPan = viewModel::onPan,
+                    onAnalysisViewStatusChanged = viewModel::analysisViewStatusListener
                 )
                 // Show a message dialog if the viewmodel reported an error
                 viewModel.messageDialogVM.apply {


### PR DESCRIPTION
## Description


This PR aims to standardize reporting the exception thrown on `AnalysisViewStatus.Error` for all analysis samples in the project via displayed dialog and console log. 

- Related PR: https://github.com/Esri/arcgis-maps-sdk-kotlin-samples/pull/502

## Links and Data


Sample issue: `runtime/kotlin/issues/7989`
- a [vTest](https://runtime-kotlin.esri.com/view/all/job/vtest/job/sampleviewer/) Job for this PR has been run
  - [x] link: https://runtime-kotlin.esri.com/view/Release/job/300.1.0/job/vtest/job/sampleviewer/10/