### PR TITLE
Propagate sample message dialog errors as test failures 

### DIFF
--- a/samples-lib/src/main/java/com/esri/arcgismaps/sample/sampleslib/components/MessageDialog.kt
+++ b/samples-lib/src/main/java/com/esri/arcgismaps/sample/sampleslib/components/MessageDialog.kt
@@ -109,6 +109,7 @@ class MessageDialogViewModel : ViewModel() {
 
     fun showMessageDialog(throwable: Throwable?) {
         throwable ?: return
+        SampleDialogExceptionRelay.publish(throwable)
         when (throwable) {
             is CriticalRenderingException -> showMessageDialog(throwable)
             is ArcGISException -> showMessageDialog(throwable)
@@ -143,5 +144,25 @@ class MessageDialogViewModel : ViewModel() {
      */
     fun dismissDialog() {
         dialogStatus = false
+    }
+}
+
+/**
+ * Process-wide queue for sample dialog exceptions so tests can fail with the original exception.
+ */
+object SampleDialogExceptionRelay {
+    private val pending = ArrayDeque<Throwable>()
+
+    @Synchronized
+    fun publish(throwable: Throwable) {
+        pending.addLast(throwable)
+    }
+
+    @Synchronized
+    fun consume(): Throwable? = if (pending.isEmpty()) null else pending.removeFirst()
+
+    @Synchronized
+    fun clear() {
+        pending.clear()
     }
 }

--- a/samples-lib/src/main/java/com/esri/arcgismaps/sample/sampleslib/components/MessageDialog.kt
+++ b/samples-lib/src/main/java/com/esri/arcgismaps/sample/sampleslib/components/MessageDialog.kt
@@ -34,6 +34,10 @@ import androidx.lifecycle.ViewModel
 import com.arcgismaps.exceptions.ArcGISException
 import com.arcgismaps.exceptions.CriticalRenderingException
 import com.esri.arcgismaps.sample.sampleslib.theme.SampleAppTheme
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 
 /**
  * Composable component to display a dialog with a message
@@ -148,21 +152,15 @@ class MessageDialogViewModel : ViewModel() {
 }
 
 /**
- * Process-wide queue for sample dialog exceptions so tests can fail with the original exception.
+ * Emits dialog exceptions so instrumentation can fail with the original exception.
  */
 object SampleDialogExceptionRelay {
-    private val pending = ArrayDeque<Throwable>()
+    private val exceptionEvents = MutableSharedFlow<Throwable>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
 
-    @Synchronized
-    fun publish(throwable: Throwable) {
-        pending.addLast(throwable)
-    }
+    val exceptions: SharedFlow<Throwable> = exceptionEvents.asSharedFlow()
 
-    @Synchronized
-    fun consume(): Throwable? = if (pending.isEmpty()) null else pending.removeFirst()
-
-    @Synchronized
-    fun clear() {
-        pending.clear()
-    }
+    fun publish(throwable: Throwable) = exceptionEvents.tryEmit(throwable)
 }


### PR DESCRIPTION
Issue details: [#7890](https://zentopia.esri.com/workspaces/kotlin-workspace-603d242421bc3a4ab636a2db/issues/gh/runtime/kotlin/7890)

## Description

PR to propagate sample message dialog errors as test failures in kotlin-products-tooling prototype 

## How to Test

Test it as a part of PR [#8087](https://devtopia.esri.com/runtime/kotlin/pull/8087) in the runtime/kotlin repo

